### PR TITLE
hwt: misc fixes + updates to support SPE backend

### DIFF
--- a/sys/arm64/coresight/coresight.c
+++ b/sys/arm64/coresight/coresight.c
@@ -186,6 +186,9 @@ coresight_backend_init(struct hwt_context *ctx)
 {
 	int error;
 
+	/* Coresight does not require kva, since TMC uses raw pages */
+	ctx->kva_req = 0;
+
 	if (ctx->mode == HWT_MODE_THREAD)
 		error = coresight_backend_init_thread(ctx);
 	else

--- a/sys/arm64/coresight/coresight.c
+++ b/sys/arm64/coresight/coresight.c
@@ -241,7 +241,7 @@ coresight_backend_configure(struct hwt_context *ctx, int cpu_id, int session_id)
 }
 
 static void
-coresight_backend_enable(int cpu_id)
+coresight_backend_enable(struct hwt_context *ctx, int cpu_id)
 {
 	struct coresight_pipeline *pipeline;
 
@@ -251,7 +251,7 @@ coresight_backend_enable(int cpu_id)
 }
 
 static void
-coresight_backend_disable(int cpu_id)
+coresight_backend_disable(struct hwt_context *ctx, int cpu_id)
 {
 	struct coresight_pipeline *pipeline;
 

--- a/sys/arm64/coresight/coresight_etm4x_acpi.c
+++ b/sys/arm64/coresight/coresight_etm4x_acpi.c
@@ -81,8 +81,9 @@ static device_method_t etm_acpi_methods[] = {
 	DEVMETHOD_END
 };
 
-DEFINE_CLASS_1(etm, etm_acpi_driver, etm_acpi_methods,
-    sizeof(struct etm_softc), etm_driver);
+DEFINE_CLASS_1(coresight_etm4x, coresight_etm4x_acpi_driver, etm_acpi_methods,
+    sizeof(struct etm_softc), coresight_etm4x_driver);
 
-EARLY_DRIVER_MODULE(etm, acpi, etm_acpi_driver, 0, 0,
+EARLY_DRIVER_MODULE(coresight_etm4x, acpi, coresight_etm4x_acpi_driver, 0, 0,
     BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);
+

--- a/sys/arm64/coresight/coresight_funnel_acpi.c
+++ b/sys/arm64/coresight/coresight_funnel_acpi.c
@@ -97,8 +97,8 @@ static device_method_t funnel_acpi_methods[] = {
 	DEVMETHOD_END
 };
 
-DEFINE_CLASS_1(funnel, funnel_acpi_driver, funnel_acpi_methods,
-    sizeof(struct funnel_softc), funnel_driver);
+DEFINE_CLASS_1(coresight_funnel, coresight_funnel_acpi_driver, funnel_acpi_methods,
+    sizeof(struct funnel_softc), coresight_funnel_driver);
 
-EARLY_DRIVER_MODULE(funnel, acpi, funnel_acpi_driver, 0, 0,
+EARLY_DRIVER_MODULE(coresight_funnel, acpi, coresight_funnel_acpi_driver, 0, 0,
     BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);

--- a/sys/arm64/coresight/coresight_replicator_acpi.c
+++ b/sys/arm64/coresight/coresight_replicator_acpi.c
@@ -82,8 +82,8 @@ static device_method_t replicator_acpi_methods[] = {
 	DEVMETHOD_END
 };
 
-DEFINE_CLASS_1(replicator, replicator_acpi_driver, replicator_acpi_methods,
-    sizeof(struct replicator_softc), replicator_driver);
+DEFINE_CLASS_1(coresight_replicator, coresight_replicator_acpi_driver, replicator_acpi_methods,
+    sizeof(struct replicator_softc), coresight_replicator_driver);
 
-EARLY_DRIVER_MODULE(replicator, acpi, replicator_acpi_driver, 0, 0,
+EARLY_DRIVER_MODULE(coresight_replicator, acpi, coresight_replicator_acpi_driver, 0, 0,
     BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);

--- a/sys/arm64/coresight/coresight_tmc_acpi.c
+++ b/sys/arm64/coresight/coresight_tmc_acpi.c
@@ -81,8 +81,8 @@ static device_method_t tmc_acpi_methods[] = {
 	DEVMETHOD_END
 };
 
-DEFINE_CLASS_1(tmc, tmc_acpi_driver, tmc_acpi_methods,
-    sizeof(struct tmc_softc), tmc_driver);
+DEFINE_CLASS_1(coresight_tmc, coresight_tmc_acpi_driver, tmc_acpi_methods,
+    sizeof(struct tmc_softc), coresight_tmc_driver);
 
-EARLY_DRIVER_MODULE(tmc, acpi, tmc_acpi_driver, 0, 0,
+EARLY_DRIVER_MODULE(coresight_tmc, acpi, coresight_tmc_acpi_driver, 0, 0,
     BUS_PASS_INTERRUPT + BUS_PASS_ORDER_MIDDLE);

--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -109,7 +109,7 @@ hwt_backend_enable(struct hwt_context *ctx, int cpu_id)
 
 	dprintf("%s\n", __func__);
 
-	ctx->hwt_backend->ops->hwt_backend_enable(cpu_id);
+	ctx->hwt_backend->ops->hwt_backend_enable(ctx, cpu_id);
 }
 
 void
@@ -118,7 +118,7 @@ hwt_backend_disable(struct hwt_context *ctx, int cpu_id)
 
 	dprintf("%s\n", __func__);
 
-	ctx->hwt_backend->ops->hwt_backend_disable(cpu_id);
+	ctx->hwt_backend->ops->hwt_backend_disable(ctx, cpu_id);
 }
 
 void __unused

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -36,8 +36,8 @@ struct hwt_backend_ops {
 	void (*hwt_backend_deinit)(struct hwt_context *);
 	int (*hwt_backend_configure)(struct hwt_context *, int cpu_id,
 	    int thread_id);
-	void (*hwt_backend_enable)(int cpu_id);
-	void (*hwt_backend_disable)(int cpu_id);
+	void (*hwt_backend_enable)(struct hwt_context *, int cpu_id);
+	void (*hwt_backend_disable)(struct hwt_context *, int cpu_id);
 	int (*hwt_backend_read)(int cpu_id, int *curpage,
 	    vm_offset_t *curpage_offset);
 

--- a/sys/dev/hwt/hwt_context.c
+++ b/sys/dev/hwt/hwt_context.c
@@ -99,6 +99,7 @@ hwt_ctx_alloc(struct hwt_context **ctx0)
 
 	ctx = malloc(sizeof(struct hwt_context), M_HWT_CTX, M_WAITOK | M_ZERO);
 	ctx->thread_counter = 0;
+	ctx->kva_req = 1; /* default require kern VAs */
 
 	LIST_INIT(&ctx->records);
 	TAILQ_INIT(&ctx->threads);

--- a/sys/dev/hwt/hwt_context.h
+++ b/sys/dev/hwt/hwt_context.h
@@ -52,6 +52,8 @@ struct hwt_context {
 	int				pause_on_mmap;
 
 	size_t				bufsize; /* Trace bufsize for each vm.*/
+	int				kva_req;
+
 	void				*config;
 	size_t				config_size;
 	int				config_version;

--- a/sys/dev/hwt/hwt_cpu.c
+++ b/sys/dev/hwt/hwt_cpu.c
@@ -88,6 +88,23 @@ hwt_cpu_first(struct hwt_context *ctx)
 	return (cpu);
 }
 
+struct hwt_cpu *
+hwt_cpu_get(struct hwt_context *ctx, int cpu_id)
+{
+	struct hwt_cpu *cpu, *tcpu;
+
+	HWT_CTX_ASSERT_LOCKED(ctx);
+
+	TAILQ_FOREACH_SAFE(cpu, &ctx->cpus, next, tcpu) {
+		KASSERT(cpu != NULL, ("cpu is NULL"));
+		if (cpu->cpu_id == cpu_id) {
+			return cpu;
+		}
+	}
+
+	return (NULL);
+}
+
 void
 hwt_cpu_insert(struct hwt_context *ctx, struct hwt_cpu *cpu)
 {

--- a/sys/dev/hwt/hwt_cpu.h
+++ b/sys/dev/hwt/hwt_cpu.h
@@ -41,6 +41,7 @@ struct hwt_cpu * hwt_cpu_alloc(void);
 void hwt_cpu_free(struct hwt_cpu *cpu);
 
 struct hwt_cpu * hwt_cpu_first(struct hwt_context *ctx);
+struct hwt_cpu * hwt_cpu_get(struct hwt_context *ctx, int cpu_id);
 void hwt_cpu_insert(struct hwt_context *ctx, struct hwt_cpu *cpu);
 
 #endif /* !_DEV_HWT_HWT_CPU_H_ */

--- a/sys/dev/hwt/hwt_hook.c
+++ b/sys/dev/hwt/hwt_hook.c
@@ -219,7 +219,7 @@ hwt_hook_thread_create(struct thread *td)
 	char path[MAXPATHLEN];
 	size_t bufsize;
 	struct proc *p;
-	int thread_id;
+	int thread_id, kva_req;
 	int error;
 
 	p = td->td_proc;
@@ -230,11 +230,12 @@ hwt_hook_thread_create(struct thread *td)
 		return (ENXIO);
 	thread_id = atomic_fetchadd_int(&ctx->thread_counter, 1);
 	bufsize = ctx->bufsize;
+	kva_req = ctx->kva_req;
 	sprintf(path, "hwt_%d_%d", ctx->ident, thread_id);
 	hwt_ctx_put(ctx);
 
 	/* Step 2. Allocate some memory without holding ctx ref. */
-	error = hwt_thread_alloc(&thr, path, bufsize);
+	error = hwt_thread_alloc(&thr, path, bufsize, kva_req);
 	if (error) {
 		printf("%s: could not allocate thread, error %d\n",
 		    __func__, error);

--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -210,7 +210,8 @@ hwt_ioctl_alloc_mode_thread(struct thread *td, struct hwt_owner *ho,
 		thread_id = atomic_fetchadd_int(&ctx->thread_counter, 1);
 		sprintf(path, "hwt_%d_%d", ctx->ident, thread_id);
 
-		error = hwt_thread_alloc(&thr, path, ctx->bufsize);
+		error = hwt_thread_alloc(&thr, path, ctx->bufsize,
+		    ctx->kva_req);
 		if (error) {
 			free(threads, M_HWT_IOCTL);
 			hwt_ctx_free(ctx);
@@ -317,7 +318,7 @@ hwt_ioctl_alloc_mode_cpu(struct thread *td, struct hwt_owner *ho,
 			continue;
 
 		sprintf(path, "hwt_%d_%d", ctx->ident, cpu_id);
-		error = hwt_vm_alloc(ctx->bufsize, path, &vm);
+		error = hwt_vm_alloc(ctx->bufsize, ctx->kva_req, path, &vm);
 		if (error) {
 			/* TODO: remove all allocated cpus. */
 			hwt_ctx_free(ctx);

--- a/sys/dev/hwt/hwt_thread.c
+++ b/sys/dev/hwt/hwt_thread.c
@@ -115,13 +115,14 @@ hwt_thread_lookup(struct hwt_context *ctx, struct thread *td)
 }
 
 int
-hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize)
+hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize,
+    int kva_req)
 {
 	struct hwt_thread *thr;
 	struct hwt_vm *vm;
 	int error;
 
-	error = hwt_vm_alloc(bufsize, path, &vm);
+	error = hwt_vm_alloc(bufsize, kva_req, path, &vm);
 	if (error)
 		return (error);
 

--- a/sys/dev/hwt/hwt_thread.h
+++ b/sys/dev/hwt/hwt_thread.h
@@ -45,7 +45,8 @@ struct hwt_thread {
 };
 
 /* Thread allocation. */
-int hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize);
+int hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize,
+    int kva_req);
 void hwt_thread_free(struct hwt_thread *thr);
 
 /* Thread list mgt. */

--- a/sys/dev/hwt/hwt_vm.h
+++ b/sys/dev/hwt/hwt_vm.h
@@ -43,7 +43,7 @@ struct hwt_vm {
 	struct hwt_thread		*thr;	/* thr mode only. */
 };
 
-int hwt_vm_alloc(size_t bufsize, char *path, struct hwt_vm **vm0);
+int hwt_vm_alloc(size_t bufsize, int kva_req, char *path, struct hwt_vm **vm0);
 void hwt_vm_free(struct hwt_vm *vm);
 
 #endif /* !_DEV_HWT_HWT_VM_H_ */

--- a/sys/dev/hwt/hwt_vm.h
+++ b/sys/dev/hwt/hwt_vm.h
@@ -35,6 +35,7 @@ struct hwt_vm {
 	vm_page_t			*pages;
 	int				npages;
 	vm_object_t			obj;
+	vm_offset_t			kvaddr;
 	struct cdev			*cdev;
 
 	struct hwt_context		*ctx;

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -167,8 +167,10 @@ hwt_ctx_alloc(struct trace_context *tc)
 	al.mode = tc->mode;
 	if (tc->mode == HWT_MODE_THREAD)
 		al.pid = tc->pid;
-	else
-		al.cpu_map = tc->cpu_map;
+	else {
+		al.cpu_map = &tc->cpu_map;
+		al.cpusetsize = sizeof(cpuset_t);
+	}
 
 	al.bufsize = tc->bufsize;
 	al.backend_name = tc->trace_dev->name;

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -158,7 +158,12 @@ hwt_ctx_alloc(struct trace_context *tc)
 {
 	struct hwt_alloc al;
 	cpuset_t cpu_map;
-	int error;
+	int error = 0;
+	
+	if (tc->trace_dev->methods->init != NULL)
+		error = tc->trace_dev->methods->init(tc);
+	if (error)
+		return (error);
 
 	CPU_ZERO(&cpu_map);
 

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -199,7 +199,7 @@ hwt_map_memory(struct trace_context *tc, int tid)
 		return (-1);
 	}
 
-	printf("%s: tc->base %#p\n", __func__, tc->base);
+	printf("%s: tc->base %p\n", __func__, tc->base);
 
 	return (0);
 }

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -35,6 +35,7 @@
 struct trace_context;
 
 struct trace_dev_methods {
+	int (*init)(struct trace_context *tc);
 	int (*process)(struct trace_context *tc);
 	int (*set_config)(struct trace_context *tc);
 };

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -36,6 +36,7 @@ struct trace_context;
 
 struct trace_dev_methods {
 	int (*init)(struct trace_context *tc);
+	int (*mmap)(struct trace_context *tc);
 	int (*process)(struct trace_context *tc);
 	int (*set_config)(struct trace_context *tc);
 };

--- a/usr.sbin/hwt/hwt_coresight.c
+++ b/usr.sbin/hwt/hwt_coresight.c
@@ -562,7 +562,7 @@ hwt_coresight_init(struct trace_context *tc, struct cs_decoder *dec,
 
 	error = create_decoder_etmv4(tc, dec->dcdtree_handle, thread_id);
 	if (error != OCSD_OK) {
-		printf("can't create decoder: tc->base %#p\n", tc->base);
+		printf("can't create decoder: tc->base %p\n", tc->base);
 		return (-2);
 	}
 

--- a/usr.sbin/hwt/hwt_coresight.c
+++ b/usr.sbin/hwt/hwt_coresight.c
@@ -802,6 +802,7 @@ hwt_coresight_process(struct trace_context *tc)
 }
 
 struct trace_dev_methods cs_methods = {
+	.init = NULL,
 	.process = hwt_coresight_process,
 	.set_config = hwt_coresight_set_config,
 };


### PR DESCRIPTION
A few different requirements for SPE backend, mainly VAs for buffers in kernel + different mmap'ing + a backend_init() function in userspace

These are the generic hwt changes to support that, plus some other minor fixes