### PR TITLE
hwt: add generic taskqueue/kqueue

### DIFF
--- a/sys/dev/hwt/hwt.c
+++ b/sys/dev/hwt/hwt.c
@@ -113,6 +113,31 @@
  *    User can start tracing by invoking HWT_IOC_START on any of character
  *    device within the context, entire context will be marked as RUNNING.
  * 4. The rest is similar to the THREAD mode.
+ *
+ *
+ * A taskqueue(9) is declared in this file for asynchronous execution of tasks
+ *	e.g. sleepable routines called from interrupt handlers
+ *
+ * to use it, extern the queue in the src file where it will be used:
+ *	extern struct taskqueue *taskqueue_hwt;
+ *
+ * then call TASK_INIT to setup a task + enqueue it:
+ *	TASK_INIT(struct *task, 0, (task_fn_t *)func, *arg);
+ *	taskqueue_enqueue(taskqueue_hwt, struct *task);
+ *
+ *
+ * A kqueue(2)(9) can be configured in userspace to allow userspace to sleep
+ * until notified by the kernel
+ *	e.g. notify userspace to service a buffer on a buffer full interrupt
+ *
+ * hwt_context ctx contains kqueue_fd + struct thread *hwt_td of the calling
+ * userspace tool.
+ *
+ * Create an event and register on kqueue to wake userspace:
+ *	EV_SET(struct *kevent, EVENT_NUM, EVFILT_USER, 0,
+ *	    NOTE_TRIGGER | NOTE_FFCOPY | uflags, data, NULL);
+ *	ret = kqfd_register(ctx->kqueue_fd, *kevent, ctx->hwt_td, M_WAITOK);
+ *
  */
 
 #include <sys/param.h>
@@ -126,6 +151,7 @@
 #include <sys/module.h>
 #include <sys/mutex.h>
 #include <sys/rwlock.h>
+#include <sys/taskqueue.h>
 
 #include <dev/hwt/hwt_context.h>
 #include <dev/hwt/hwt_contexthash.h>
@@ -144,6 +170,8 @@
 #else
 #define	dprintf(fmt, ...)
 #endif
+
+TASKQUEUE_FAST_DEFINE_THREAD(hwt);
 
 static eventhandler_tag hwt_exit_tag;
 static struct cdev *hwt_cdev;

--- a/sys/dev/hwt/hwt_context.h
+++ b/sys/dev/hwt/hwt_context.h
@@ -40,6 +40,9 @@ struct hwt_context {
 	int				mode;
 	int				ident;
 
+	int				kqueue_fd;
+	struct thread			*hwt_td;
+
 	/* CPU mode. */
 	cpuset_t			cpu_map;
 	TAILQ_HEAD(, hwt_cpu)		cpus;

--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -157,6 +157,8 @@ hwt_ioctl_alloc_mode_thread(struct thread *td, struct hwt_owner *ho,
 	ctx->hwt_backend = backend;
 	ctx->hwt_owner = ho;
 	ctx->mode = HWT_MODE_THREAD;
+	ctx->hwt_td = td;
+	ctx->kqueue_fd = halloc->kqueue_fd;
 
 	error = copyout(&ctx->ident, halloc->ident, sizeof(int));
 	if (error) {
@@ -306,6 +308,8 @@ hwt_ioctl_alloc_mode_cpu(struct thread *td, struct hwt_owner *ho,
 	ctx->hwt_owner = ho;
 	ctx->mode = HWT_MODE_CPU;
 	ctx->cpu_map = cpu_map;
+	ctx->hwt_td = td;
+	ctx->kqueue_fd = halloc->kqueue_fd;
 
 	error = copyout(&ctx->ident, halloc->ident, sizeof(int));
 	if (error) {

--- a/sys/sys/hwt.h
+++ b/sys/sys/hwt.h
@@ -60,6 +60,7 @@ struct hwt_alloc {
 	size_t		cpusetsize;
 	const char	*backend_name;
 	int		*ident;
+	int		kqueue_fd;
 } __aligned(16);
 
 struct hwt_start {

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -180,6 +180,7 @@ hwt_ctx_alloc(struct trace_context *tc)
 	al.bufsize = tc->bufsize;
 	al.backend_name = tc->trace_dev->name;
 	al.ident = &tc->ident;
+	al.kqueue_fd = tc->kqueue_fd;
 
 	error = ioctl(tc->fd, HWT_IOC_ALLOC, &al);
 

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -59,6 +59,7 @@ struct trace_context {
 	int fd;
 	int thr_fd;
 	int terminate;
+	int kqueue_fd;
 
 	int thread_id;
 	int ident;


### PR DESCRIPTION
There's not too many generic changes to support kqueue since setup/config of this is mostly backend specific (e.g. registering/encoding custom events)

Taskqueue is just a single macro
