### PR TITLE
hwt - initial Intel PT backend commit

### DIFF
--- a/sys/amd64/amd64/trap.c
+++ b/sys/amd64/amd64/trap.c
@@ -45,6 +45,7 @@
 #include "opt_clock.h"
 #include "opt_cpu.h"
 #include "opt_hwpmc_hooks.h"
+#include "opt_hwt_hooks.h"
 #include "opt_isa.h"
 #include "opt_kdb.h"
 
@@ -72,6 +73,10 @@
 PMC_SOFT_DEFINE( , , page_fault, all);
 PMC_SOFT_DEFINE( , , page_fault, read);
 PMC_SOFT_DEFINE( , , page_fault, write);
+#endif
+
+#ifdef HWT_HOOKS
+#include <dev/hwt/hwt_intr.h>
 #endif
 
 #include <vm/vm.h>
@@ -249,6 +254,12 @@ trap(struct trapframe *frame)
 	}
 
 	if (type == T_NMI) {
+#ifdef HWT_HOOKS
+	    	if(hwt_intr != NULL &&
+		    (*hwt_intr)(frame) != 0)
+      			return;
+#endif
+
 #ifdef HWPMC_HOOKS
 		/*
 		 * CPU PMCs interrupt using an NMI.  If the PMC module is

--- a/sys/amd64/pt/pt.c
+++ b/sys/amd64/pt/pt.c
@@ -1,0 +1,828 @@
+/*-
+ * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/cdefs.h>
+#include <sys/types.h>
+#include <sys/param.h>
+#include <sys/systm.h>
+#include <sys/event.h>
+#include <sys/hwt.h>
+#include <sys/kernel.h>
+#include <sys/module.h>
+#include <sys/mutex.h>
+#include <sys/proc.h>
+#include <sys/queue.h>
+#include <sys/sdt.h>
+#include <sys/smp.h>
+#include <sys/errno.h>
+#include <sys/taskqueue.h>
+#include <sys/domainset.h>
+#include <sys/sleepqueue.h>
+
+#include <vm/vm.h>
+#include <vm/vm_page.h>
+
+#include <machine/cpufunc.h>
+#include <machine/param.h>
+#include <machine/atomic.h>
+#include <machine/smp.h>
+#include <machine/specialreg.h>
+
+#include <x86/apicvar.h>
+#include <x86/x86_var.h>
+
+#include <dev/hwt/hwt_vm.h>
+#include <dev/hwt/hwt_thread.h>
+#include <dev/hwt/hwt_cpu.h>
+#include <dev/hwt/hwt_config.h>
+#include <dev/hwt/hwt_context.h>
+#include <dev/hwt/hwt_backend.h>
+#include <dev/hwt/hwt_hook.h>
+#include <dev/hwt/hwt_intr.h>
+
+#include "pt.h"
+
+#ifdef PT_DEBUG
+#define dprintf(fmt, ...) printf(fmt, ##__VA_ARGS__)
+#else
+#define dprintf(fmt, ...)
+#endif
+
+#define PT_XSAVE_MASK (XFEATURE_ENABLED_X87 | XFEATURE_ENABLED_SSE)
+
+MALLOC_DEFINE(M_PT, "pt", "Intel Processor Trace");
+
+SDT_PROVIDER_DECLARE(pt);
+SDT_PROBE_DEFINE(pt, , , topa__intr);
+
+extern struct taskqueue *taskqueue_hwt;
+
+static bool loaded = false;
+
+struct pt_save_area {
+	uint8_t legacy_state[512];
+	struct xsave_header header;
+	struct pt_ext_area pt_ext_area;
+} __aligned(64);
+
+struct pt_buffer {
+	uint64_t *topa_hw;  /* ToPA table entries. */
+	struct mtx pmi_mtx; /* spinlock for pt_backend_read */
+	bool ready;
+	vm_offset_t offset;
+	int curpage;
+};
+
+struct pt_ctx {
+	struct pt_buffer buf;  /* ToPA buffer metadata */
+	struct task task;      /* ToPA buffer kevent task */
+	struct thread *hwt_td; /* hwt(8) tracing thread */
+	int kqueue_fd;
+	struct pt_save_area save_area; /* PT XSAVE area */
+};
+
+/* XXX: WIP */
+struct pt_thread {
+	struct pt_ctx ctx;
+};
+
+static struct pt_cpu {
+	struct hwt_thread *hwt_td; /* hwt thread active on cpu */
+	struct pt_ctx ctx;	   /* save area for CPU mode */
+	volatile int terminating;  /* used as part of trace stop protocol */
+} *pt_pcpu;
+
+/*
+ * PT-related CPUID bits.
+ */
+static struct pt_cpu_info {
+	uint32_t l0_eax;
+	uint32_t l0_ebx;
+	uint32_t l0_ecx;
+	uint32_t l1_eax;
+	uint32_t l1_ebx;
+} pt_info;
+
+static int pt_topa_intr(struct trapframe *tf);
+
+static __inline void
+xrstors(char *addr, uint64_t mask)
+{
+	uint32_t low, hi;
+
+	low = mask;
+	hi = mask >> 32;
+	__asm __volatile("xrstors %0" : : "m"(*addr), "a"(low), "d"(hi));
+}
+
+static __inline void
+xsaves(char *addr, uint64_t mask)
+{
+	uint32_t low, hi;
+
+	low = mask;
+	hi = mask >> 32;
+	__asm __volatile("xsaves %0"
+			 : "=m"(*addr)
+			 : "a"(low), "d"(hi)
+			 : "memory");
+}
+
+/*
+ * Enables or disables tracing on curcpu.
+ */
+static void
+pt_cpu_toggle_local(struct pt_save_area *save_area, bool enable)
+{
+	u_long xcr0, cr0;
+	u_long xss;
+
+	KASSERT((curthread)->td_critnest >= 1,
+	    ("%s: not in critical section", __func__));
+
+	cr0 = rcr0();
+	if (cr0 & CR0_TS)
+		clts();
+	xcr0 = rxcr(XCR0);
+	if ((xcr0 & PT_XSAVE_MASK) != PT_XSAVE_MASK)
+		load_xcr(XCR0, xcr0 | PT_XSAVE_MASK);
+	xss = rdmsr(MSR_IA32_XSS);
+	wrmsr(MSR_IA32_XSS, xss | XFEATURE_ENABLED_PT);
+
+	if (!enable) {
+		KASSERT((rdmsr(MSR_IA32_RTIT_CTL) & RTIT_CTL_TRACEEN) != 0,
+		    ("%s: PT is disabled", __func__));
+		xsaves((char *)save_area, XFEATURE_ENABLED_PT);
+	} else {
+		KASSERT((rdmsr(MSR_IA32_RTIT_CTL) & RTIT_CTL_TRACEEN) == 0,
+		    ("%s: PT is enabled", __func__));
+		xrstors((char *)save_area, XFEATURE_ENABLED_PT);
+	}
+	wrmsr(MSR_IA32_XSS, xss);
+	if ((xcr0 & PT_XSAVE_MASK) != PT_XSAVE_MASK)
+		load_xcr(XCR0, xcr0);
+	if (cr0 & CR0_TS)
+		load_cr0(cr0);
+}
+
+/*
+ * Dumps contents of PT-related registers.
+ */
+static void
+pt_cpu_dump(int cpu_id)
+{
+#ifdef PT_DEBUG
+	struct pt_save_area *area = &pt_pcpu[cpu_id].ctx.save_area;
+
+	printf("dumping PT info for cpu %d\n", cpu_id);
+
+	printf("rtit_ctl: 0x%zx\n", area->pt_ext_area.rtit_ctl);
+	printf("rtit_addr0_a: 0x%zx\n", area->pt_ext_area.rtit_addr0_a);
+	printf("rtit_addr0_b: 0x%zx\n", area->pt_ext_area.rtit_addr0_b);
+
+	printf("xsave_bv: 0x%zx\n", area->header.xsave_bv);
+	printf("xcomp_bv: 0x%zx\n", area->header.xcomp_bv);
+
+	printf("rtit_status MSR: 0x%zx\n", rdmsr(MSR_IA32_RTIT_STATUS));
+	printf("rtit_ctl MSR: 0x%zx\n", rdmsr(MSR_IA32_RTIT_CTL));
+	printf("rtit output base MSR: 0x%zx\n",
+	    rdmsr(MSR_IA32_RTIT_OUTPUT_BASE));
+	printf("rtit mask_ptrs MSR: 0x%zx\n",
+	    rdmsr(MSR_IA32_RTIT_OUTPUT_MASK_PTRS));
+	printf("rtit_addr0_a MSR: 0x%zx\n", rdmsr(MSR_IA32_RTIT_ADDR0_A));
+
+	lapic_dump("0");
+#endif
+}
+
+/*
+ * CPU mode helper routines.
+ */
+static void
+pt_cpu_init(void *dummy)
+{
+	struct pt_cpu *cpu = &pt_pcpu[curcpu];
+	dprintf("%s: curcpu %d\n", __func__, curcpu);
+	/* Enable XSAVE. */
+	load_cr4(rcr4() | CR4_XSAVE);
+	/* Clear PMI status. */
+	wrmsr(MSR_IA32_RTIT_STATUS, 0);
+	/* Start tracing. */
+	pt_cpu_toggle_local(&cpu->ctx.save_area, true);
+	pt_cpu_dump(curcpu);
+}
+
+static void
+pt_cpu_stop(void *dummy)
+{
+	struct pt_cpu *cpu = &pt_pcpu[curcpu];
+	dprintf("%s: curcpu %d\n", __func__, curcpu);
+	/* Check if the CPU was initialized */
+	if (cpu->ctx.buf.topa_hw == NULL)
+		return;
+	/* Stop tracing. */
+	pt_cpu_toggle_local(&cpu->ctx.save_area, false);
+}
+
+/*
+ * Disables ToPA PMI on curcpu.
+ * Used as an smp_rendevous action function.
+ */
+static void
+pt_cpu_mask_pcint(void *dummy __unused)
+{
+	pt_cpu_dump(curcpu);
+	lapic_disable_pt_pmi();
+}
+
+static int
+pt_topa_prepare(struct pt_ctx *ctx, struct hwt_vm *vm)
+{
+	int i;
+	struct pt_buffer *buf = &ctx->buf;
+	size_t topa_size = TOPA_SIZE_4K; /* 4K only for now */
+
+	KASSERT(buf->topa_hw == NULL,
+	    ("%s: ToPA info already exists", __func__));
+	/* Allocate array of TOPA entries. */
+	buf->topa_hw = malloc((vm->npages + 1) * sizeof(uint64_t), M_PT,
+	    M_WAITOK | M_ZERO);
+	dprintf("%s: ToPA virt addr %p\n", __func__, buf->topa_hw);
+	for (i = 0; i < vm->npages; i++) {
+		buf->topa_hw[i] = VM_PAGE_TO_PHYS(vm->pages[i]) | topa_size;
+		/*
+		 * XXX: TOPA_INT should ideally be set according to
+		 * expected amount of incoming trace data. Too few TOPA_INT
+		 * entries will not trigger interrupts often enough when tracing
+		 * smaller functions.
+		 */
+		/* Raise interrupt when entry is filled. */
+		buf->topa_hw[i] |= TOPA_INT;
+	}
+	/* Circular buffer - point last entry to first */
+	buf->topa_hw[vm->npages] = (uint64_t)vtophys(buf->topa_hw) | TOPA_END;
+
+	return (0);
+}
+
+static int
+pt_backend_init_thread(struct hwt_context *ctx)
+{
+	struct hwt_thread *thr;
+
+	HWT_CTX_LOCK(ctx);
+	TAILQ_FOREACH (thr, &ctx->threads, next) {
+		KASSERT(thr->cookie == NULL,
+		    ("%s: thr->cookie not NULL - %p", __func__, thr->cookie));
+		thr->cookie = malloc(sizeof(struct pt_thread), M_PT,
+		    M_ZERO | M_WAITOK);
+	}
+	HWT_CTX_UNLOCK(ctx);
+
+	return (ENXIO);
+}
+
+static int
+pt_configure_ranges(struct pt_ctx *ctx, struct pt_cpu_config *cfg)
+{
+	struct pt_ext_area *pt_ext;
+	struct pt_save_area *save_area;
+	int nranges_supp, n, error = 0;
+
+	save_area = &ctx->save_area;
+	pt_ext = &save_area->pt_ext_area;
+
+	if (pt_info.l0_ebx & CPUPT_IPF) {
+		/* How many IP ranges does the CPU support? */
+		nranges_supp = (pt_info.l1_eax & CPUPT_NADDR_M) >>
+		    CPUPT_NADDR_S;
+
+		/* xsave/xrstor supports two ranges only. */
+		if (nranges_supp > 2)
+			nranges_supp = 2;
+		n = cfg->nranges;
+		if (n > nranges_supp) {
+			printf(
+			    "%s: %d IP filtering ranges requested, CPU supports %d, truncating\n",
+			    __func__, n, nranges_supp);
+			n = nranges_supp;
+		}
+
+		switch (n) {
+		case 2:
+			pt_ext->rtit_ctl |= (1UL << RTIT_CTL_ADDR_CFG_S(1));
+			pt_ext->rtit_addr1_a = cfg->ip_ranges[1].start;
+			pt_ext->rtit_addr1_b = cfg->ip_ranges[1].end;
+		case 1:
+			pt_ext->rtit_ctl |= (1UL << RTIT_CTL_ADDR_CFG_S(0));
+			pt_ext->rtit_addr0_a = cfg->ip_ranges[0].start;
+			pt_ext->rtit_addr0_b = cfg->ip_ranges[0].end;
+			break;
+		default:
+			error = (EINVAL);
+			break;
+		};
+	} else {
+		error = (ENXIO);
+	}
+
+	return error;
+}
+
+// TODO: decouple configuration logic from CPU mode
+static int
+pt_backend_configure(struct hwt_context *ctx, int cpu_id, int session_id)
+{
+	struct pt_ctx *pt_ctx;
+	struct hwt_cpu *hwt_cpu;
+	struct pt_ext_area *pt_ext;
+	struct xsave_header *hdr;
+	struct pt_cpu_config *cfg = (struct pt_cpu_config *)ctx->config;
+	int error = 0;
+
+	dprintf("%s\n", __func__);
+
+	/* Sanitize input. */
+	// cfg->rtit_ctl &= PT_SUPPORTED_FLAGS;
+	/* Validate user configuration */
+	if (cfg->rtit_ctl & RTIT_CTL_MTCEN) {
+		if ((pt_info.l0_ebx & CPUPT_MTC) == 0) {
+			printf(
+			    "%s: CPU does not support generating MTC packets\n",
+			    __func__);
+			return (ENXIO);
+		}
+	}
+
+	if (cfg->rtit_ctl & RTIT_CTL_CR3FILTER) {
+		if ((pt_info.l0_ebx & CPUPT_CR3) == 0) {
+			printf("%s: CPU does not support CR3 filtering\n",
+			    __func__);
+			return (ENXIO);
+		}
+	}
+
+	if (cfg->rtit_ctl & RTIT_CTL_DIS_TNT) {
+		if ((pt_info.l0_ebx & CPUPT_DIS_TNT) == 0) {
+			printf("%s: CPU does not support TNT\n", __func__);
+			return (ENXIO);
+		}
+	}
+	/* TODO: support for more config bits */
+
+	TAILQ_FOREACH (hwt_cpu, &ctx->cpus, next) {
+		if (hwt_cpu->cpu_id != cpu_id)
+			continue;
+
+		dprintf("%s: cpuid %d\n", __func__, cpu_id);
+		pt_ctx = &pt_pcpu[cpu_id].ctx;
+		pt_ext = &pt_ctx->save_area.pt_ext_area;
+		hdr = &pt_ctx->save_area.header;
+
+		KASSERT(pt_ctx->buf.topa_hw == NULL,
+		    ("%s: active ToPA buffer in cpu %d\n", __func__,
+			hwt_cpu->cpu_id));
+		memset(&pt_pcpu[hwt_cpu->cpu_id], 0, sizeof(struct pt_cpu));
+
+		dprintf("%s: preparing IPF ranges\n", __func__);
+		pt_ext->rtit_ctl |= cfg->rtit_ctl;
+		if ((error = pt_configure_ranges(pt_ctx, cfg)) != 0) {
+			return error;
+		}
+
+		dprintf("%s: preparing ToPA buffer\n", __func__);
+		if (pt_topa_prepare(pt_ctx, hwt_cpu->vm) != 0) {
+			dprintf("%s: failed to prepare ToPA buffer\n",
+			    __func__);
+			return (-1);
+		}
+
+		dprintf("%s: preparing MSRs\n", __func__);
+		/* Save hwt_td for kevent */
+		pt_ctx->hwt_td = ctx->hwt_td;
+		pt_ctx->kqueue_fd = ctx->kqueue_fd;
+		/* Prepare ToPA MSR values. */
+		pt_ext->rtit_ctl |= RTIT_CTL_TOPA;
+		pt_ext->rtit_output_base = (uint64_t)vtophys(
+		    pt_ctx->buf.topa_hw);
+		pt_ext->rtit_output_mask_ptrs = 0x7f;
+		/* Init header */
+		hdr->xsave_bv = XFEATURE_ENABLED_PT;
+		hdr->xcomp_bv = XFEATURE_ENABLED_PT |
+		    (1ULL << 63) /* compaction */;
+		/* Enable tracing. */
+		pt_ext->rtit_ctl |= RTIT_CTL_TRACEEN;
+	}
+	return (0);
+}
+
+/*
+ * hwt backend trace start operation. CPU affine.
+ */
+static void
+pt_backend_enable(struct hwt_context *ctx, int cpu_id)
+{
+	KASSERT(curcpu == cpu_id,
+	    ("%s: attempting to start PT on another cpu", __func__));
+	pt_cpu_init(NULL);
+}
+
+/*
+ * hwt backend trace stop operation. CPU affine.
+ */
+static void
+pt_backend_disable(struct hwt_context *ctx, int cpu_id)
+{
+	KASSERT(curcpu == cpu_id,
+	    ("%s: attempting to disable PT on another cpu", __func__));
+	pt_cpu_stop(NULL);
+}
+
+/*
+ * hwt backend trace start operation for remote CPUs.
+ */
+static void
+pt_backend_enable_smp(struct hwt_context *ctx)
+{
+	dprintf("%s\n", __func__);
+	smp_rendezvous_cpus(ctx->cpu_map, NULL, pt_cpu_init, NULL, NULL);
+}
+
+/*
+ * hwt backend trace stop operation for remote CPUs.
+ */
+static void
+pt_backend_disable_smp(struct hwt_context *ctx)
+{
+	int cpu_id;
+	struct pt_cpu *cpu;
+
+	dprintf("%s\n", __func__);
+	/* Signal trace stop to active interrupt handlers. */
+	CPU_FOREACH (cpu_id) {
+		if (!CPU_ISSET(cpu_id, &ctx->cpu_map))
+			continue;
+		cpu = &pt_pcpu[cpu_id];
+		atomic_store_int(&cpu->terminating, 1);
+	}
+	/* Mask ToPA PMI on active CPUs. */
+	smp_rendezvous_cpus(ctx->cpu_map, NULL, pt_cpu_mask_pcint, NULL, NULL);
+	/* Wait for each CPU to exit ISR. */
+	pause((void *)pt_backend_disable_smp, hz / 4);
+	/* Deactivate PT. */
+	smp_rendezvous_cpus(ctx->cpu_map, NULL, pt_cpu_stop, NULL, NULL);
+}
+
+static int
+pt_backend_init(struct hwt_context *ctx)
+{
+	int error = 0;
+
+	dprintf("%s\n", __func__);
+	if (ctx->mode == HWT_MODE_THREAD)
+		error = pt_backend_init_thread(ctx);
+	if (error != 0)
+		return (error);
+
+	/* Configure PMI on all CPUs. */
+	if (lapic_enable_pmc() == 0) {
+		printf("%s: unable to enable pcint interrupts\n", __func__);
+		return (-1);
+	}
+	/* Install ToPA PMI handler. */
+	KASSERT(hwt_intr == NULL,
+	    ("%s: ToPA PMI handler already present", __func__));
+	hwt_intr = pt_topa_intr;
+	wmb();
+
+	return (error);
+}
+
+static void
+pt_backend_deinit(struct hwt_context *ctx)
+{
+	/* struct hwt_thread *thr; */
+	struct pt_cpu *cpu;
+
+	dprintf("%s\n", __func__);
+
+	/* Remove ToPA PMI handler. */
+	hwt_intr = NULL;
+	wmb();
+
+	/* Stop tracing on all active CPUs */
+	pt_backend_disable_smp(ctx);
+	lapic_disable_pmc();
+	if (ctx->mode == HWT_MODE_THREAD) {
+		/* HWT_CTX_LOCK(ctx); */
+		/* TAILQ_FOREACH (thr, &ctx->threads, next) { */
+		/* 	KASSERT(thr->cookie != NULL, */
+		/* 	    ("%s: thr->cookie not set", __func__)); */
+		/* 	free(thr->cookie, M_PT); */
+		/* 	thr->cookie = NULL; */
+		/* } */
+		/* HWT_CTX_UNLOCK(ctx); */
+	} else {
+		CPU_FOREACH (cpu_id) {
+			if (!CPU_ISSET(cpu_id, &ctx->cpu_map))
+				continue;
+			cpu = &pt_pcpu[cpu_id];
+			/* Free ToPA table. */
+			free(cpu->ctx.buf.topa_hw, M_PT);
+			cpu->ctx.buf.topa_hw = NULL;
+		}
+	}
+}
+
+/*
+ * Fetches new offset into the tracing buffer, if any.
+ * Blocks until notified by the PMI interrupt handler.
+ */
+static int
+pt_backend_read(int cpu_id, int *curpage, vm_offset_t *curpage_offset)
+{
+	int error = 0;
+	struct pt_buffer *buf = &pt_pcpu[cpu_id].ctx.buf;
+
+	dprintf("%s\n", __func__);
+	if (buf->topa_hw == NULL)
+		return (-1);
+
+	mtx_lock_spin(&buf->pmi_mtx);
+	if (!buf->ready) {
+		if (msleep_spin(buf, &buf->pmi_mtx, "ptread", 0) ==
+		    EWOULDBLOCK) {
+			error = ENOENT;
+			goto out;
+		}
+		if (!buf->ready) {
+			error = ENOENT;
+			goto out;
+		}
+	}
+	*curpage = buf->curpage;
+	*curpage_offset = buf->offset;
+	buf->ready = false;
+	wmb();
+out:
+	mtx_unlock_spin(&buf->pmi_mtx);
+
+	return (error);
+}
+
+static void
+pt_backend_dump(int cpu_id)
+{
+	return;
+}
+
+static struct hwt_backend_ops pt_ops = {
+	.hwt_backend_init = pt_backend_init,
+	.hwt_backend_deinit = pt_backend_deinit,
+
+	.hwt_backend_configure = pt_backend_configure,
+
+	.hwt_backend_enable = pt_backend_enable,
+	.hwt_backend_disable = pt_backend_disable,
+
+#ifdef SMP
+	.hwt_backend_enable_smp = pt_backend_enable_smp,
+	.hwt_backend_disable_smp = pt_backend_disable_smp,
+#endif
+
+	.hwt_backend_read = pt_backend_read,
+	.hwt_backend_dump = pt_backend_dump,
+};
+static struct hwt_backend backend = {
+	.ops = &pt_ops,
+	.name = "pt",
+};
+
+/*
+ * ToPA PMI kevent task.
+ */
+static void
+pt_buffer_ready(void *arg, int pending __unused)
+{
+	struct pt_ctx *ctx = arg;
+	struct kevent kev;
+	int ret __diagused;
+	int64_t data = (ctx->buf.curpage * PAGE_SIZE) + ctx->buf.offset;
+
+	dprintf("%s: cpu %d, kqueue_fd %d, data 0x%zx, td %p\n", __func__,
+	    curcpu, ctx->kqueue_fd, data, ctx->hwt_td);
+	EV_SET(&kev, HWT_PT_BUF_RDY_EV, EVFILT_USER, 0, NOTE_TRIGGER, data,
+	    NULL);
+	ret = kqfd_register(ctx->kqueue_fd, &kev, ctx->hwt_td, M_WAITOK);
+	dprintf("%s: kqfd ret %d\n", __func__, ret);
+	KASSERT(ret == 0,
+	    ("%s: kqueue fd register failed: %d\n", __func__, ret));
+}
+
+/*
+ * ToPA PMI handler.
+ */
+static int
+pt_topa_intr(struct trapframe *tf)
+{
+	int retval = 0;
+	uint64_t reg;
+	struct pt_ctx *ctx;
+	struct pt_buffer *buf;
+
+	SDT_PROBE0(pt, , , topa__intr);
+	/* TODO: handle possible double entry */
+	/* Check ToPA PMI status on curcpu. */
+	reg = rdmsr(MSR_IA_GLOBAL_STATUS);
+	if ((reg & GLOBAL_STATUS_FLAG_TRACETOPAPMI) == 0)
+		return (retval);
+
+	/* Disable preemption. */
+	critical_enter();
+	retval = 1;
+	/* Only CPU mode supported for now */
+	ctx = &pt_pcpu[curcpu].ctx;
+	buf = &ctx->buf;
+	KASSERT(buf->topa_hw != NULL,
+	    ("%s: ToPA PMI interrupt with invalid buffer", __func__));
+
+	/* Disable tracing so we don't trace the PMI handler. */
+	pt_cpu_toggle_local(&ctx->save_area, false);
+	/* Update buffer offset. */
+	reg = rdmsr(MSR_IA32_RTIT_OUTPUT_MASK_PTRS);
+
+	mtx_lock_spin(&buf->pmi_mtx);
+	buf->curpage = (reg & 0xffffff80) >> 7;
+	buf->offset = reg >> 32;
+	buf->ready = true;
+	wmb();
+	mtx_unlock_spin(&buf->pmi_mtx);
+
+	/* Notify pt_backend_read. */
+	wakeup(buf);
+	dprintf("%s: woke up pt_backend_read\n", __func__);
+
+	/* XXX: kevents registered this way never make it to userspace. */
+	/* TASK_INIT(&ctx->task, 0, (task_fn_t *)pt_buffer_ready, ctx); */
+	/* taskqueue_enqueue(taskqueue_hwt, &ctx->task); */
+
+	/* Clear ToPA PMI status. */
+	reg = rdmsr(MSR_IA_GLOBAL_STATUS_RESET);
+	reg &= ~GLOBAL_STATUS_FLAG_TRACETOPAPMI;
+	reg |= GLOBAL_STATUS_FLAG_TRACETOPAPMI;
+	wrmsr(MSR_IA_GLOBAL_STATUS_RESET, reg);
+
+	/* Don't re-enable ToPA PMI if trace stop was requested. */
+	if (atomic_load_acq_int(&pt_pcpu[curcpu].terminating) == 0)
+		lapic_reenable_pmc();
+	/* Re-enable tracing. */
+	pt_cpu_toggle_local(&ctx->save_area, true);
+	/* Enable preemption. */
+	critical_exit();
+
+	return (retval);
+}
+
+static int
+pt_init(void)
+{
+	u_int cp[4];
+
+	dprintf("Enumerating part 1\n");
+
+	cpuid_count(PT_CPUID, 0, cp);
+	dprintf("%s: Maximum valid sub-leaf Index: %x\n", __func__, cp[0]);
+	dprintf("%s: ebx %x\n", __func__, cp[1]);
+	dprintf("%s: ecx %x\n", __func__, cp[2]);
+
+	/* Save relevant cpuid info. */
+	pt_info.l0_eax = cp[0];
+	pt_info.l0_ebx = cp[1];
+	pt_info.l0_ecx = cp[2];
+
+	dprintf("Enumerating part 2\n");
+
+	cpuid_count(PT_CPUID, 1, cp);
+	dprintf("%s: eax %x\n", __func__, cp[0]);
+	dprintf("%s: ebx %x\n", __func__, cp[1]);
+
+	pt_info.l1_eax = cp[0];
+	pt_info.l1_ebx = cp[1];
+
+	return (0);
+}
+
+static bool
+pt_supported(void)
+{
+	u_int cp[4];
+
+	/* Intel SDM Vol. 3C, 33-30 */
+	if ((cpu_stdext_feature & CPUID_STDEXT_PROCTRACE) == 0) {
+		printf("pt: CPU does not support Intel Processor Trace\n");
+		return (false);
+	}
+
+	/* Require XSAVE support. */
+	if ((cpu_feature2 & CPUID2_XSAVE) == 0) {
+		printf("pt: XSAVE is not supported\n");
+		return (false);
+	}
+
+	cpuid_count(0xd, 0x0, cp);
+	if ((cp[0] & PT_XSAVE_MASK) != PT_XSAVE_MASK) {
+		printf("pt: CPU does not support X87 or SSE: %x", cp[0]);
+		return (false);
+	}
+
+	cpuid_count(0xd, 0x1, cp);
+	if ((cp[0] & (1 << 0)) == 0) {
+		printf("pt: XSAVE compaction is not supported\n");
+		return (false);
+	}
+	if ((cp[0] & (1 << 3)) == 0) {
+		printf("pt: XSAVES/XRSTORS are not supported\n");
+		return (false);
+	}
+
+	/* Require ToPA support. */
+	cpuid_count(PT_CPUID, 0, cp);
+	if ((cp[2] & CPUPT_TOPA) == 0) {
+		printf("pt: ToPA is not supported\n");
+		return (false);
+	}
+	if ((cp[2] & CPUPT_TOPA_MULTI) == 0) {
+		printf("pt: multiple ToPA outputs are not supported\n");
+		return (false);
+	}
+
+	return (true);
+}
+
+static int
+pt_modevent(module_t mod, int type, void *data)
+{
+	int error;
+
+	switch (type) {
+	case MOD_LOAD:
+		if (!pt_supported()) {
+			return (ENXIO);
+		}
+		pt_init();
+		error = hwt_backend_register(&backend);
+		if (error != 0) {
+			printf("pt: unable to register hwt backend, error %d\n",
+			    error);
+			return (error);
+		}
+		pt_pcpu = malloc(sizeof(struct pt_cpu) * mp_ncpus, M_PT,
+		    M_ZERO | M_WAITOK);
+		for (int i = 0; i < mp_ncpus; i++)
+			mtx_init(&pt_pcpu[i].ctx.buf.pmi_mtx, "ToPA PMI", NULL,
+			    MTX_SPIN);
+		loaded = true;
+		break;
+	case MOD_UNLOAD:
+		if (loaded) {
+			hwt_backend_unregister(&backend);
+			hwt_intr = NULL;
+			free(pt_pcpu, M_PT);
+			pt_pcpu = NULL;
+		}
+		break;
+	default:
+		break;
+	}
+
+	return (0);
+}
+
+static moduledata_t pt_mod = { "intel_pt", pt_modevent, NULL };
+
+DECLARE_MODULE(intel_pt, pt_mod, SI_SUB_DRIVERS, SI_ORDER_FIRST);
+MODULE_DEPEND(intel_pt, hwt, 1, 1, 1);
+MODULE_VERSION(intel_pt, 1);

--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -121,6 +121,24 @@ hwt_backend_disable(struct hwt_context *ctx, int cpu_id)
 	ctx->hwt_backend->ops->hwt_backend_disable(ctx, cpu_id);
 }
 
+void
+hwt_backend_enable_smp(struct hwt_context *ctx)
+{
+
+	dprintf("%s\n", __func__);
+
+	ctx->hwt_backend->ops->hwt_backend_enable_smp(ctx);
+}
+
+void
+hwt_backend_disable_smp(struct hwt_context *ctx)
+{
+
+	dprintf("%s\n", __func__);
+
+	ctx->hwt_backend->ops->hwt_backend_disable_smp(ctx);
+}
+
 void __unused
 hwt_backend_dump(struct hwt_context *ctx, int cpu_id)
 {

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -40,6 +40,9 @@ struct hwt_backend_ops {
 	void (*hwt_backend_disable)(struct hwt_context *, int cpu_id);
 	int (*hwt_backend_read)(int cpu_id, int *curpage,
 	    vm_offset_t *curpage_offset);
+	/* For backends that are tied to local CPU registers */
+	void (*hwt_backend_enable_smp)(struct hwt_context *);
+	void (*hwt_backend_disable_smp)(struct hwt_context *);
 
 	/* Debugging only. */
 	void (*hwt_backend_dump)(int cpu_id);
@@ -55,6 +58,8 @@ void hwt_backend_deinit(struct hwt_context *ctx);
 int hwt_backend_configure(struct hwt_context *ctx, int cpu_id, int thread_id);
 void hwt_backend_enable(struct hwt_context *ctx, int cpu_id);
 void hwt_backend_disable(struct hwt_context *ctx, int cpu_id);
+void hwt_backend_enable_smp(struct hwt_context *ctx);
+void hwt_backend_disable_smp(struct hwt_context *ctx);
 void hwt_backend_dump(struct hwt_context *ctx, int cpu_id);
 int hwt_backend_read(struct hwt_context *ctx, int cpu_id, int *curpage,
     vm_offset_t *curpage_offset);

--- a/sys/dev/hwt/hwt_config.c
+++ b/sys/dev/hwt/hwt_config.c
@@ -33,6 +33,7 @@
 #include <sys/kernel.h>
 #include <sys/malloc.h>
 #include <sys/mutex.h>
+#include <sys/lock.h>
 #include <sys/hwt.h>
 
 #include <vm/vm.h>

--- a/sys/dev/hwt/hwt_intr.h
+++ b/sys/dev/hwt/hwt_intr.h
@@ -1,10 +1,5 @@
 /*-
- * SPDX-License-Identifier: BSD-2-Clause
- *
- * Copyright (c) 2023 Ruslan Bukin <br@bsdpad.com>
- *
- * This work was supported by Innovate UK project 105694, "Digital Security
- * by Design (DSbD) Technology Platform Prototype".
+ * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -26,23 +21,15 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
+ *
+ * $FreeBSD$
  */
 
-#include <sys/param.h>
-#include <sys/eventhandler.h>
-#include <sys/ioccom.h>
-#include <sys/conf.h>
-#include <sys/proc.h>
-#include <sys/kernel.h>
-#include <sys/malloc.h>
-#include <sys/mman.h>
-#include <sys/module.h>
-#include <sys/mutex.h>
-#include <sys/rwlock.h>
-#include <sys/hwt.h>
+#ifndef _DEV_HWT_HWT_INTR_H_
+#define _DEV_HWT_HWT_INTR_H_
 
-#include <dev/hwt/hwt_hook.h>
-#include <dev/hwt/hwt_intr.h>
+#include <machine/frame.h>
 
-void __read_mostly (*hwt_hook)(struct thread *td, int func, void *arg) = NULL;
-int __read_mostly (*hwt_intr)(struct trapframe *tf) = NULL;
+extern int (*hwt_intr)(struct trapframe *tf);
+
+#endif /* !_DEV_HWT_HWT_INTR_H_ */

--- a/sys/dev/hwt/hwt_thread.h
+++ b/sys/dev/hwt/hwt_thread.h
@@ -42,6 +42,7 @@ struct hwt_thread {
 	struct mtx			mtx;
 	u_int				refcnt;
 	int				cpu_id; /* last cpu_id */
+	void				*cookie; /* backend-specific data */
 };
 
 /* Thread allocation. */

--- a/sys/modules/pt/Makefile
+++ b/sys/modules/pt/Makefile
@@ -1,0 +1,8 @@
+
+.PATH: ${SRCTOP}/sys/amd64/pt
+
+KMOD=   pt
+SRCS=   pt.c pt.h device_if.h bus_if.h
+SRCS+=  opt_hwpmc_hooks.h opt_kstack_pages.h
+
+.include <bsd.kmod.mk>

--- a/sys/x86/include/apicvar.h
+++ b/sys/x86/include/apicvar.h
@@ -230,6 +230,8 @@ void	lapic_reenable_pmc(void);
 void	lapic_enable_cmc(void);
 int	lapic_enable_mca_elvt(void);
 void	lapic_ipi_raw(register_t icrlo, u_int dest);
+void 	lapic_enable_pt_pmi(void);
+void 	lapic_disable_pt_pmi(void);
 
 static inline void
 lapic_ipi_vectored(u_int vector, int dest)

--- a/sys/x86/include/specialreg.h
+++ b/sys/x86/include/specialreg.h
@@ -105,6 +105,7 @@
 #define	XFEATURE_ENABLED_OPMASK		0x00000020
 #define	XFEATURE_ENABLED_ZMM_HI256	0x00000040
 #define	XFEATURE_ENABLED_HI16_ZMM	0x00000080
+#define	XFEATURE_ENABLED_PT		0x00000100
 #define	XFEATURE_ENABLED_PKRU		0x00000200
 #define	XFEATURE_ENABLED_TILECONFIG	0x00020000
 #define	XFEATURE_ENABLED_TILEDATA	0x00040000
@@ -195,6 +196,7 @@
 #define	CPUPT_MTC		(1 << 3)	/* MTC Supported */
 #define	CPUPT_PRW		(1 << 4)	/* PTWRITE Supported */
 #define	CPUPT_PWR		(1 << 5)	/* Power Event Trace Supported */
+#define	CPUPT_DIS_TNT		(1 << 8)	/* TNT disable supported */
 
 /* Leaf 0 ecx. */
 #define	CPUPT_TOPA		(1 << 0)	/* ToPA Output Supported */
@@ -596,6 +598,12 @@
 #define	MSR_PAT			0x277
 #define	MSR_MC0_CTL2		0x280
 #define	MSR_MTRRdefType		0x2ff
+#define	MSR_IA_GLOBAL_STATUS    0x38E
+#define	MSR_IA_GLOBAL_CTRL      0x38F
+#define	MSR_IA_GLOBAL_OVF_CTRL  0x390
+#define	MSR_IA_GLOBAL_STATUS_RESET	0x390
+#define	MSR_IA_GLOBAL_STATUS_SET	0x391
+#define	 GLOBAL_STATUS_FLAG_TRACETOPAPMI	(1ULL << 55)
 #define	MSR_MC0_CTL		0x400
 #define	MSR_MC0_STATUS		0x401
 #define	MSR_MC0_ADDR		0x402
@@ -723,6 +731,7 @@
 #define	 RTIT_CTL_ADDR2_CFG_M	(0xfULL << RTIT_CTL_ADDR2_CFG_S)
 #define	 RTIT_CTL_ADDR3_CFG_S	44
 #define	 RTIT_CTL_ADDR3_CFG_M	(0xfULL << RTIT_CTL_ADDR3_CFG_S)
+#define	RTIT_CTL_DIS_TNT	(1ULL << 55)
 #define	MSR_IA32_RTIT_STATUS		0x571	/* Tracing Status Register (R/W) */
 #define	 RTIT_STATUS_FILTEREN	(1 << 0)
 #define	 RTIT_STATUS_CONTEXTEN	(1 << 1)

--- a/sys/x86/x86/local_apic.c
+++ b/sys/x86/x86/local_apic.c
@@ -36,6 +36,7 @@
 #include <sys/cdefs.h>
 #include "opt_atpic.h"
 #include "opt_hwpmc_hooks.h"
+#include "opt_hwt_hooks.h"
 
 #include "opt_ddb.h"
 
@@ -819,6 +820,28 @@ lapic_reenable_pmc(void)
 	lapic_write32(LAPIC_LVT_PCINT, value);
 #endif
 }
+
+#ifdef HWT_HOOKS
+void
+lapic_enable_pt_pmi(void)
+{
+        uint32_t value = 0;
+        value |= APIC_LVT_DM_NMI;
+        lapic_write32(LAPIC_LVT_PCINT, value);
+}
+
+void
+lapic_disable_pt_pmi(void)
+{
+        uint32_t value;
+
+        value = lapic_read32(LAPIC_LVT_PCINT);
+        value |= APIC_LVT_M;
+        lapic_write32(LAPIC_LVT_PCINT, value);
+}
+
+#endif
+
 
 #ifdef HWPMC_HOOKS
 static void

--- a/usr.sbin/Makefile.amd64
+++ b/usr.sbin/Makefile.amd64
@@ -21,3 +21,4 @@ SUBDIR+=	lptcontrol
 SUBDIR+=	mptable
 SUBDIR+=	spkrtest
 SUBDIR+=	zzz
+SUBDIR+=	hwt

--- a/usr.sbin/hwt/Makefile
+++ b/usr.sbin/hwt/Makefile
@@ -16,6 +16,9 @@ SRCS=	hwt.c			\
 .if ${MACHINE_CPUARCH} == "aarch64"
 SRCS+=	hwt_coresight.c
 LIBADD+= opencsd
+.elif ${MACHINE_CPUARCH} == "amd64"
+SRCS+=  hwt_pt.c
+LIBADD+= ipt
 .endif
 
 .include <bsd.prog.mk>

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -61,6 +61,11 @@
 #include "hwt_coresight.h"
 #endif
 
+#if defined(__amd64__)
+#include "hwt_pt.h"
+#endif
+
+
 #define	HWT_DEBUG
 #undef	HWT_DEBUG
 
@@ -79,6 +84,9 @@ static struct trace_context tcs;
 static struct trace_dev trace_devs[] = {
 #if defined(__aarch64__)
 	{ "coresight",	"ARM Coresight", &cs_methods },
+#endif
+#if defined(__amd64__)
+	{ "pt", "Intel PT", &pt_methods},
 #endif
 	{ NULL, NULL, NULL }
 };

--- a/usr.sbin/hwt/hwt_pt.c
+++ b/usr.sbin/hwt/hwt_pt.c
@@ -1,0 +1,428 @@
+/*-
+ * Copyright (c) 2023 Bojan Novković  <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/param.h>
+#include <sys/cpuset.h>
+#include <sys/errno.h>
+#include <sys/event.h>
+#include <sys/hwt.h>
+#include <sys/ioctl.h>
+#include <sys/mman.h>
+#include <sys/socket.h>
+#include <sys/sysctl.h>
+#include <sys/wait.h>
+
+#include <err.h>
+#include <libipt/intel-pt.h>
+#include <libxo/xo.h>
+#include <stdio.h>
+#include <string.h>
+#include <assert.h>
+
+#include "hwt.h"
+#include "hwt_pt.h"
+#include "sys/_stdint.h"
+#include "sys/systm.h"
+#include "sys/types.h"
+
+#define pt_strerror(errcode) pt_errstr(pt_errcode((errcode)))
+
+/*
+ * Decoder per-cpu state.
+ */
+static struct hwt_pt_cpu {
+	size_t curoff;
+	void *tracebuf;
+	struct pt_packet_decoder *dec;
+} *hwt_pt_pcpu;
+
+static int
+hwt_pt_init(struct trace_context *tc)
+{
+
+	hwt_pt_pcpu = calloc(hwt_ncpu(), sizeof(struct hwt_pt_cpu));
+	if (!hwt_pt_pcpu) {
+		printf("%s: failed to allocate decoder\n", __func__);
+		return (-1);
+	}
+	if (tc->raw) {
+		/* No decoder needed, just a file for raw data. */
+		tc->raw_f = fopen(tc->filename, "w");
+		if (tc->raw_f == NULL) {
+			printf("%s: could not open file %s\n", __func__,
+			    tc->filename);
+			return (ENXIO);
+		}
+	}
+
+	return (0);
+}
+
+static int
+hwt_pt_mmap(struct trace_context *tc)
+{
+	int error;
+	int cpu_id, tc_fd = -1, _fd;
+	struct hwt_pt_cpu *cpu;
+	struct pt_config config;
+
+	if (tc->mode == HWT_MODE_CPU) {
+		CPU_FOREACH_ISSET (cpu_id, &tc->cpu_map) {
+			cpu = &hwt_pt_pcpu[cpu_id];
+
+			error = hwt_map_tracebuf(tc, cpu_id,
+			    tc_fd == -1 ? &tc_fd : &_fd, &cpu->tracebuf);
+			if (error != 0) {
+				printf(
+				    "%s: failed to map tracing buffer for cpu %d: %s\n",
+				    __func__, cpu_id, strerror(errno));
+				return (-1);
+			}
+
+			if (!tc->raw) {
+				memset(&config, 0, sizeof(config));
+				config.size = sizeof(config);
+				config.begin = cpu->tracebuf;
+				config.end = (uint8_t *)cpu->tracebuf +
+				    tc->bufsize;
+
+				cpu->dec = pt_pkt_alloc_decoder(&config);
+				if (cpu->dec == NULL) {
+					printf(
+					    "%s: failed to allocate PT decoder for cpu %d\n",
+					    __func__, cpu_id);
+					return (-1);
+				}
+			}
+		}
+	} else {
+		return (-1);
+	}
+
+	/* thr_fd is used to issue ioctls which control all cores
+	 * use fd to the first cpu for this (thread is always 0) */
+	assert(tc_fd != -1);
+	tc->thr_fd = tc_fd;
+
+	return (0);
+}
+
+static int
+hwt_pt_set_config(struct trace_context *tc)
+{
+	struct hwt_set_config sconf;
+	struct pt_cpu_config *config;
+	int i, error;
+	uint64_t rtit_ctl = 0;
+
+	config = calloc(1, sizeof(struct pt_cpu_config));
+	/* Fill config */
+	if (tc->mode == HWT_MODE_THREAD)
+		rtit_ctl |= RTIT_CTL_USER;
+	else
+		rtit_ctl |= RTIT_CTL_OS;
+
+	if (tc->nranges) {
+		/* IP range filtering. */
+		config->nranges = tc->nranges;
+		for (i = 0; i < tc->nranges; i++) {
+			config->ip_ranges[i].start = tc->addr_ranges[i * 2];
+			config->ip_ranges[i].end = tc->addr_ranges[i * 2 + 1];
+		}
+	}
+
+	rtit_ctl |= RTIT_CTL_BRANCHEN;
+
+	config->rtit_ctl = rtit_ctl;
+	tc->config = config;
+
+	sconf.config = config;
+	sconf.config_size = sizeof(struct pt_config);
+	sconf.config_version = 1;
+	sconf.pause_on_mmap = tc->suspend_on_mmap ? 1 : 0;
+
+	error = ioctl(tc->thr_fd, HWT_IOC_SET_CONFIG, &sconf);
+
+	return (error);
+}
+
+static void
+hwt_pt_print_tnt(const struct pt_packet_tnt *packet)
+{
+	uint64_t tnt;
+	uint8_t bits;
+
+	bits = packet->bit_size;
+	tnt = packet->payload;
+
+	while (--bits)
+		putc(tnt & (1ull << (bits - 1)) ? '!' : '.', stdout);
+}
+
+static void
+hwt_pt_print_mode(const struct pt_packet_mode *pkt)
+{
+	enum pt_exec_mode mode;
+
+	switch (pkt->leaf) {
+	case pt_mol_exec: {
+		printf(".exec: ");
+		mode = pt_get_exec_mode(&pkt->bits.exec);
+		switch (mode) {
+		case ptem_64bit:
+			printf("64-bit");
+			break;
+		case ptem_32bit:
+			printf("32-bit");
+			break;
+		case ptem_16bit:
+			printf("16-bit");
+			break;
+		default:
+			printf("unknown");
+			break;
+		}
+		break;
+	}
+	case pt_mol_tsx:
+		printf(".tsx");
+		break;
+	}
+}
+
+static int
+hwt_pt_print_packet(const struct pt_packet *pkt)
+{
+
+	switch (pkt->type) {
+	case ppt_unknown:
+		printf("<unknown>");
+		break;
+	case ppt_invalid:
+		printf("<invalid>");
+		break;
+	case ppt_tnt_8:
+		printf("tnt.8\n");
+		hwt_pt_print_tnt(&pkt->payload.tnt);
+		break;
+	case ppt_tnt_64:
+		printf("tnt.64\n");
+		hwt_pt_print_tnt(&pkt->payload.tnt);
+		break;
+	case ppt_mode:
+		printf("mode");
+		hwt_pt_print_mode(&pkt->payload.mode);
+		break;
+	case ppt_pip:
+		printf("pip: cr3 %p", (void *)pkt->payload.pip.cr3);
+		break;
+	case ppt_vmcs:
+		printf("vmcs: %p", (void *)pkt->payload.vmcs.base);
+		break;
+	case ppt_cbr:
+		printf("cbr: ratio %u", pkt->payload.cbr.ratio);
+		break;
+	case ppt_tip_pge:
+		printf("pge: TRACE START @%p", (void *)pkt->payload.ip.ip);
+		break;
+	case ppt_tip_pgd:
+		printf("pgd: TRACE STOP @%p", (void *)pkt->payload.ip.ip);
+		break;
+	case ppt_fup:
+		printf("fup: @%p", (void *)pkt->payload.ip.ip);
+		break;
+	case ppt_pad:
+	case ppt_psb:
+	case ppt_psbend:
+		/* Ignore */
+		return (0);
+	default:
+		printf("%s: unknown packet type encountered: %d\n", __func__,
+		    pkt->type);
+		return (-1);
+	}
+	printf("\n");
+
+	return (0);
+}
+
+static int
+hwt_pt_decode_chunk(struct pt_packet_decoder *dec, uint64_t start, size_t len,
+    uint64_t *processed)
+{
+	int error = 0;
+	uint64_t prevoffs, offs;
+	int ret;
+	struct pt_packet packet;
+
+	printf("%s: start %zu, len %zu\n", __func__, start, len);
+
+	offs = prevoffs = start;
+	/* Set decoder to current offset. */
+	pt_pkt_sync_set(dec, start);
+
+	do {
+		ret = pt_pkt_next(dec, &packet, sizeof(packet));
+		if (ret < 0) {
+			if (ret == -pte_eos) {
+				/* Restore previous offset */
+				pt_pkt_sync_set(dec, prevoffs);
+				offs = prevoffs;
+			} else {
+				error = ret;
+				printf("%s: error decoding next packet: %s\n",
+				    __func__, pt_strerror(error));
+			}
+			break;
+		}
+		error = hwt_pt_print_packet(&packet);
+		if (error < 0) {
+			printf("%s: error while processing packet: %s\n",
+			    __func__, pt_strerror(error));
+			break;
+		}
+
+		prevoffs = offs;
+		offs += ret;
+
+		if (offs > (start + len))
+			break;
+	} while (1);
+	*processed = offs - start;
+
+	return (error);
+}
+
+/*
+ * Dumps raw packet bytes into tc->raw_f.
+ */
+static int
+hwt_pt_dump_chunk(struct hwt_pt_cpu *cpu, FILE *raw_f, uint64_t offs,
+    size_t len, uint64_t *processed)
+{
+	void *base;
+
+	base = (void *)((uintptr_t)cpu->tracebuf + (uintptr_t)offs);
+	fwrite(base, len, 1, raw_f);
+	fflush(raw_f);
+
+	*processed = len;
+
+	return (0);
+}
+
+static int
+pt_process_chunk(struct trace_context *tc, struct hwt_pt_cpu *cpu,
+    uint64_t offs, size_t len, uint64_t *processed)
+{
+	if (tc->raw) {
+		return hwt_pt_dump_chunk(cpu, tc->raw_f, offs, len, processed);
+	} else {
+		return hwt_pt_decode_chunk(cpu->dec, offs, len, processed);
+	}
+}
+
+static int
+hwt_pt_process(struct trace_context *tc)
+{
+	uint64_t curoff, newoff;
+	size_t totals;
+	int error;
+	int len, cpu_id = 0; // assume cpu_id == 0 for now
+	uint64_t processed;
+	struct hwt_pt_cpu *cpu;
+
+	xo_open_container("trace");
+	xo_open_list("entries");
+
+	printf("Decoder started. Press ctrl+c to stop.\n");
+
+	curoff = 0;
+	processed = 0;
+	totals = 0;
+	len = 0;
+
+	while (1) {
+		printf("%s: fetching new offset\n", __func__);
+		error = hwt_get_offs(tc, &newoff);
+		if (error < 0)
+			err(EXIT_FAILURE, "hwt_get_offs");
+		printf("%s: new offset %zu\n", __func__, newoff);
+
+		cpu = &hwt_pt_pcpu[cpu_id];
+		curoff = cpu->curoff;
+		if (newoff == curoff) {
+			if (tc->terminate)
+				break;
+		} else if (newoff > curoff) {
+			/* New entries in the trace buffer. */
+			len = newoff - curoff;
+			if (pt_process_chunk(tc, cpu, curoff, len,
+				&processed)) {
+				break;
+			}
+			curoff += processed;
+			totals += processed;
+
+		} else if (newoff < curoff) {
+			/* New entries in the trace buffer. Buffer wrapped. */
+			len = tc->bufsize - curoff;
+			if (pt_process_chunk(tc, cpu, curoff, len,
+				&processed)) {
+				break;
+			}
+			curoff += processed;
+			totals += processed;
+
+			curoff = 0;
+			len = newoff;
+			if (pt_process_chunk(tc, cpu, curoff, len,
+				&processed)) {
+				break;
+			}
+			curoff += processed;
+			totals += processed;
+		}
+		/* Save current offset for cpu */
+		cpu->curoff = curoff;
+	}
+
+	printf("\nBytes processed: %ld\n", totals);
+
+	xo_close_list("file");
+	xo_close_container("wc");
+	if (xo_finish() < 0)
+		xo_err(EXIT_FAILURE, "stdout");
+
+	return (0);
+}
+
+struct trace_dev_methods pt_methods = {
+	.init = hwt_pt_init,
+	.mmap = hwt_pt_mmap,
+	.process = hwt_pt_process,
+	.set_config = hwt_pt_set_config,
+};

--- a/usr.sbin/hwt/hwt_pt.h
+++ b/usr.sbin/hwt/hwt_pt.h
@@ -1,10 +1,6 @@
 /*-
- * SPDX-License-Identifier: BSD-2-Clause
- *
- * Copyright (c) 2023 Ruslan Bukin <br@bsdpad.com>
- *
- * This work was supported by Innovate UK project 105694, "Digital Security
- * by Design (DSbD) Technology Platform Prototype".
+ * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -28,21 +24,10 @@
  * SUCH DAMAGE.
  */
 
-#include <sys/param.h>
-#include <sys/eventhandler.h>
-#include <sys/ioccom.h>
-#include <sys/conf.h>
-#include <sys/proc.h>
-#include <sys/kernel.h>
-#include <sys/malloc.h>
-#include <sys/mman.h>
-#include <sys/module.h>
-#include <sys/mutex.h>
-#include <sys/rwlock.h>
-#include <sys/hwt.h>
+#ifndef _HWT_PT_H_
+#define _HWT_PT_H_
 
-#include <dev/hwt/hwt_hook.h>
-#include <dev/hwt/hwt_intr.h>
+#include <amd64/pt/pt.h>
 
-void __read_mostly (*hwt_hook)(struct thread *td, int func, void *arg) = NULL;
-int __read_mostly (*hwt_intr)(struct trapframe *tf) = NULL;
+extern struct trace_dev_methods pt_methods;
+#endif /* !_HWT_PT_H_ */

--- a/usr.sbin/hwt/hwt_record.c
+++ b/usr.sbin/hwt/hwt_record.c
@@ -143,6 +143,17 @@ hwt_record_fetch(struct trace_context *tc, int *nrecords)
 				return (-1);
 			if (image->pi_type == PMCSTAT_IMAGE_UNKNOWN)
 				pmcstat_image_determine_type(image, &args);
+			/*
+			 * Some images have no executable sections - skip them.
+			 */
+			if (image->pi_end == 0) {
+				printf(
+				    "  image '%s' has no executable sections, skipping\n",
+				    imagepath);
+				free(image);
+				image = NULL;
+				break;
+			}
 			addr = (unsigned long)entry->addr & ~1;
 			pmcstat_image_link(tc->pp, image, addr);
 			break;


### PR DESCRIPTION
This is the initial version of the Intel PT hwt backend.

I've noticed several duplicated functions and discrepancies between my sources and those on freebsd-morello/hwt.
I will update the patch to reflect those changes - please ignore these issues for now.

Aside from this, I have stumbled upon several issues while writing this driver:
-  Issues with `cpu_map` in `struct trace_context`
Starting a trace in CPU mode would result in wrong CPUs getting started. For instance, starting CPU mode on cpu 0 turned on CPUS 6 and 7. The issue was related to the way `cpu_map` was transferred over to the `hwt` module
- `kevent` delivery not working
I couldn't get the `kqueue` bits to work. Everything gets initialized properly, `kqfd_register` goes through without any errors, yet the userspace never unblocks from `kevent()`. I'm not sure what is causing this, but I've temporarily cobbled together a spinlock-based waiting blocking mechanism for reading trace buffer offsets.
- Initializing core-local resources
Since PT is controlled via local MSRs, I had to add two new `hwt_backend` operations that use `smp_rendevous` to control tracing on remote CPUs
- Trace interrupt handlers
I've added a new global `hwt_intr` interrupt handler for this 

I'd also like to have a clear idea of what the output of the userspace decoder should look like so `hwt` can be consistent across different architectures. So far I've just implemented a basic packet dumper, but this is likely not what we want.