### PR TITLE
hwt: more misc fixes + updates to support SPE backend

### DIFF
--- a/sys/dev/hwt/hwt.c
+++ b/sys/dev/hwt/hwt.c
@@ -45,7 +45,7 @@
  *
  * /dev/hwt:
  *    .ioctl:
- *        hwt_ioctl(): 
+ *        hwt_ioctl():
  *               a) HWT_IOC_ALLOC
  *                  Allocates kernel tracing context CTX based on requested mode
  *                  of operation. Verifies the information that comes with the
@@ -72,6 +72,9 @@
  *               e) HWT_IOC_BUFPTR_GET
  *                  Transfers current hardware pointer in the filling buffer
  *                  to the userspace.
+ *               f) HWT_IOC_SVC_BUF
+ *                  To avoid data loss, userspace may notify kernel it has
+ *                  copied out the given buffer, so kernel is ok to overwrite
  *
  * HWT context lifecycle in THREAD mode of operation:
  * 1. User invokes HWT_IOC_ALLOC ioctl with information about pid to trace and

--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -224,3 +224,11 @@ hwt_backend_unload(void)
 
 	mtx_destroy(&hwt_backend_mtx);
 }
+
+void
+hwt_backend_stop(struct hwt_context *ctx)
+{
+	dprintf("%s\n", __func__);
+
+	ctx->hwt_backend->ops->hwt_backend_stop(ctx);
+}

--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -232,3 +232,15 @@ hwt_backend_stop(struct hwt_context *ctx)
 
 	ctx->hwt_backend->ops->hwt_backend_stop(ctx);
 }
+
+int
+hwt_backend_svc_buf(struct hwt_context *ctx, int cpu_id)
+{
+	int error;
+
+	dprintf("%s\n", __func__);
+
+	error = ctx->hwt_backend->ops->hwt_backend_svc_buf(ctx, cpu_id);
+
+	return (error);
+}

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -40,6 +40,7 @@ struct hwt_backend_ops {
 	void (*hwt_backend_disable)(struct hwt_context *, int cpu_id);
 	int (*hwt_backend_read)(int cpu_id, int *curpage,
 	    vm_offset_t *curpage_offset);
+	void (*hwt_backend_stop)(struct hwt_context *);
 
 	/* Debugging only. */
 	void (*hwt_backend_dump)(int cpu_id);
@@ -60,6 +61,7 @@ int hwt_backend_read(struct hwt_context *ctx, int cpu_id, int *curpage,
     vm_offset_t *curpage_offset);
 int hwt_backend_register(struct hwt_backend *);
 int hwt_backend_unregister(struct hwt_backend *);
+void hwt_backend_stop(struct hwt_context *);
 struct hwt_backend * hwt_backend_lookup(const char *name);
 
 void hwt_backend_load(void);

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -36,6 +36,7 @@ struct hwt_backend_ops {
 	void (*hwt_backend_deinit)(struct hwt_context *);
 	int (*hwt_backend_configure)(struct hwt_context *, int cpu_id,
 	    int thread_id);
+	int (*hwt_backend_svc_buf)(struct hwt_context *, int cpu_id);
 	void (*hwt_backend_enable)(struct hwt_context *, int cpu_id);
 	void (*hwt_backend_disable)(struct hwt_context *, int cpu_id);
 	int (*hwt_backend_read)(int cpu_id, int *curpage,
@@ -62,6 +63,7 @@ int hwt_backend_read(struct hwt_context *ctx, int cpu_id, int *curpage,
 int hwt_backend_register(struct hwt_backend *);
 int hwt_backend_unregister(struct hwt_backend *);
 void hwt_backend_stop(struct hwt_context *);
+int hwt_backend_svc_buf(struct hwt_context *ctx, int cpu_id);
 struct hwt_backend * hwt_backend_lookup(const char *name);
 
 void hwt_backend_load(void);

--- a/sys/dev/hwt/hwt_context.h
+++ b/sys/dev/hwt/hwt_context.h
@@ -31,6 +31,11 @@
 #ifndef _DEV_HWT_HWT_CONTEXT_H_
 #define _DEV_HWT_HWT_CONTEXT_H_
 
+enum hwt_ctx_state {
+	CTX_STATE_STOPPED,
+	CTX_STATE_RUNNING,
+};
+
 struct hwt_context {
 	LIST_HEAD(, hwt_record_entry)	records;
 
@@ -65,8 +70,7 @@ struct hwt_context {
 	struct hwt_backend		*hwt_backend;
 
 	struct mtx			mtx;
-	int				state;
-#define	CTX_STATE_RUNNING		(1 << 0)
+	enum hwt_ctx_state		state;
 	int				refcnt;
 };
 

--- a/sys/dev/hwt/hwt_vm.c
+++ b/sys/dev/hwt/hwt_vm.c
@@ -275,7 +275,11 @@ hwt_vm_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		break;
 
 	case HWT_IOC_STOP:
-		/* TODO */
+		if (ctx->state == CTX_STATE_STOPPED) {
+			return (ENXIO);
+		}
+		hwt_backend_stop(ctx);
+		ctx->state = CTX_STATE_STOPPED;
 		break;
 
 	case HWT_IOC_RECORD_GET:

--- a/sys/dev/hwt/hwt_vm.c
+++ b/sys/dev/hwt/hwt_vm.c
@@ -329,6 +329,19 @@ hwt_vm_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 		if (error)
 			return (error);
 		break;
+
+	case HWT_IOC_SVC_BUF:
+		if (ctx->state == CTX_STATE_STOPPED) {
+			return (ENXIO);
+		}
+		cpu_id = *addr;
+		if (cpu_id > mp_ncpus)
+			return (ENXIO);
+		error = hwt_backend_svc_buf(ctx, cpu_id);
+		if (error)
+			return (error);
+		break;
+
 	default:
 		break;
 	}

--- a/sys/sys/hwt.h
+++ b/sys/sys/hwt.h
@@ -46,6 +46,7 @@
 #define	HWT_IOC_BUFPTR_GET	_IOW(HWT_MAGIC, 0x04, struct hwt_bufptr_get)
 #define	HWT_IOC_SET_CONFIG	_IOW(HWT_MAGIC, 0x05, struct hwt_set_config)
 #define	HWT_IOC_WAKEUP		_IOW(HWT_MAGIC, 0x06, struct hwt_wakeup)
+#define	HWT_IOC_SVC_BUF		_IOW(HWT_MAGIC, 0x07, int)
 
 #define	HWT_BACKEND_MAXNAMELEN	256
 

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -197,28 +197,6 @@ hwt_ncpu(void)
 	return (ncpu);
 }
 
-int
-hwt_get_offs(struct trace_context *tc, size_t *offs)
-{
-	struct hwt_bufptr_get bget;
-	vm_offset_t curpage_offset;
-	int curpage;
-	int error;
-
-	bget.curpage = &curpage;
-	bget.curpage_offset = &curpage_offset;
-
-	error = ioctl(tc->thr_fd, HWT_IOC_BUFPTR_GET, &bget);
-	if (error)
-		return (error);
-
-	dprintf("curpage %d curpage_offset %ld\n", curpage, curpage_offset);
-
-	*offs = curpage * PAGE_SIZE + curpage_offset;
-
-	return (0);
-}
-
 static int
 hwt_get_records(struct trace_context *tc, uint32_t *nrec)
 {

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -266,6 +266,17 @@ hwt_start_tracing(struct trace_context *tc)
 	return (error);
 }
 
+int
+hwt_stop_tracing(struct trace_context *tc)
+{
+	struct hwt_stop s;
+	int error;
+
+	error = ioctl(tc->thr_fd, HWT_IOC_STOP, &s);
+
+	return (error);
+}
+
 static void
 usage(void)
 {

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -91,7 +91,6 @@ int hwt_process_create(int *sockpair, char **cmd, char **env, int *pid0);
 int hwt_process_start(int *sockpair);
 int hwt_record_fetch(struct trace_context *tc, int *nrecords);
 void hwt_procexit(pid_t pid, int status);
-int hwt_get_offs(struct trace_context *tc, size_t *offs);
 void hwt_sleep(int msec);
 int hwt_elf_count_libs(const char *elf_path, uint32_t *nlibs0);
 int hwt_find_sym(struct trace_context *tc);

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -96,6 +96,7 @@ void hwt_sleep(int msec);
 int hwt_elf_count_libs(const char *elf_path, uint32_t *nlibs0);
 int hwt_find_sym(struct trace_context *tc);
 int hwt_start_tracing(struct trace_context *tc);
+int hwt_stop_tracing(struct trace_context *tc);
 int hwt_mmap_received(struct trace_context *tc,
     struct hwt_record_user_entry *entry);
 int hwt_ncpu(void);


### PR DESCRIPTION
A few more generic changes in preparation to enable SPE (and some more general fixes):

- For SPE/PT, change the backend enable/disable interface to take a cpuset_t instead of a cpuid. Now we can pass the entire cpuset to an SMP call to enable/disable all at once. For Coresight where we're not using SMP, we can just iterate through the map in CS specific code. Downside is, we do still want to enable/disable a single CPU for thread mode, but in that case we can just pass in a cpuset with a single CPU in. Either this approach or having a separate `hwt_backend_enable_cpus(ctx)` like [bnovkov's alternative](https://github.com/bnovkov/freebsd-src/blob/4e80d8cad88a0ca7e6f1a420c797b3fa2b143545/sys/dev/hwt/hwt_vm.c#L211) would work just as good, I'm not sure if either of these is better or preferred.
    - [hwt: backend_enable/disable takes cpuset](https://github.com/CTSRD-CHERI/freebsd-morello/commit/6f25dd74e88cad154ce134ddfa9b3b6effbd60d7)
    - [hwt: coresight: enable/disable uses cpuset](https://github.com/CTSRD-CHERI/freebsd-morello/commit/cd0c8209ee437623812644ac3399692a8878b8d7)

- For SPE (+ possibly PT?), added a new ioctl as a way for userspace to signal to the kernel that it's serviced/copied out a buffer. For SPE, kernel is waiting for userspace to notify that it's copied out a buffer to avoid data loss/overwriting buffers. Not sure on naming for this one:
    - [hwt: add IOC_SVC_BUF + backend_op](https://github.com/CTSRD-CHERI/freebsd-morello/commit/77142b22772fee7e0c2a120e75a31b84720ef294)

- Implement the STOP ioctl + add a backend op for it:
    - [hwt: add IOC_STOP + backend_op](https://github.com/CTSRD-CHERI/freebsd-morello/commit/a14f13fa4e652f3e53ee7cc23b4262f9ca8a3a99)
    - [hwt: usr: add hwt_stop_tracing](https://github.com/CTSRD-CHERI/freebsd-morello/commit/3370fc083ae7d722121c375b7697c50e90ace013)

- 2 commits just remove some Coresight specific stuff in common code since it shouldn't apply to other backends:
    - [hwt: allow multiple backends for IOC_BUFPTR_GET](https://github.com/CTSRD-CHERI/freebsd-morello/commit/5f4ffb3f4549072321aac4a92504bee36017324f)
    - [hwt: usr: make get_offs cs specific](https://github.com/CTSRD-CHERI/freebsd-morello/commit/23d98e7da380e9a718adbb8967525baecb21ae37)

Thanks,
Zach