### PR TITLE
Initial MODE_THREAD commit for Intel PT

### DIFF
--- a/sys/amd64/pt/pt.h
+++ b/sys/amd64/pt/pt.h
@@ -33,8 +33,6 @@
 
 #define IP_FILTER_MAX_RANGES (4) /* Intel SDM Vol. 3C, 33-29 */
 
-#define HWT_PT_BUF_RDY_EV 138
-
 struct pt_cpu_config {
 	uint64_t rtit_ctl;
 	register_t cr3_filter;

--- a/sys/conf/files
+++ b/sys/conf/files
@@ -1778,6 +1778,7 @@ dev/hwt/hwt_config.c		optional hwt
 dev/hwt/hwt_context.c		optional hwt
 dev/hwt/hwt_contexthash.c	optional hwt
 dev/hwt/hwt_cpu.c		optional hwt
+dev/hwt/hwt_event.c		optional hwt
 dev/hwt/hwt_hook.c		optional hwt
 dev/hwt/hwt_ioctl.c		optional hwt
 dev/hwt/hwt_owner.c		optional hwt

--- a/sys/dev/hwt/hwt.c
+++ b/sys/dev/hwt/hwt.c
@@ -164,6 +164,7 @@
 #include <dev/hwt/hwt_backend.h>
 #include <dev/hwt/hwt_ioctl.h>
 #include <dev/hwt/hwt_hook.h>
+#include <dev/hwt/hwt_event.h>
 
 #define	HWT_DEBUG
 #undef	HWT_DEBUG
@@ -173,8 +174,6 @@
 #else
 #define	dprintf(fmt, ...)
 #endif
-
-TASKQUEUE_FAST_DEFINE_THREAD(hwt);
 
 static eventhandler_tag hwt_exit_tag;
 static struct cdev *hwt_cdev;

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -31,6 +31,7 @@
 #ifndef _DEV_HWT_HWT_BACKEND_H_
 #define _DEV_HWT_HWT_BACKEND_H_
 
+struct hwt_thread;
 struct hwt_backend_ops {
 	int (*hwt_backend_init)(struct hwt_context *);
 	void (*hwt_backend_deinit)(struct hwt_context *);
@@ -45,7 +46,9 @@ struct hwt_backend_ops {
 	/* For backends that are tied to local CPU registers */
 	void (*hwt_backend_enable_smp)(struct hwt_context *);
 	void (*hwt_backend_disable_smp)(struct hwt_context *);
-
+	/* Allocation and initialization of backend-specific thread data. */
+	int (*hwt_backend_alloc_thread_priv)(struct hwt_thread *);
+	void (*hwt_backend_free_thread_priv)(struct hwt_thread *);
 	/* Debugging only. */
 	void (*hwt_backend_dump)(int cpu_id);
 };

--- a/sys/dev/hwt/hwt_config.c
+++ b/sys/dev/hwt/hwt_config.c
@@ -48,7 +48,7 @@
 #define	HWT_MAXCONFIGSIZE	PAGE_SIZE
 
 #define	HWT_CONFIG_DEBUG
-#undef	HWT_CONFIG_DEBUG
+//#undef	HWT_CONFIG_DEBUG
 
 #ifdef	HWT_CONFIG_DEBUG
 #define	dprintf(fmt, ...)	printf(fmt, ##__VA_ARGS__)

--- a/sys/dev/hwt/hwt_event.c
+++ b/sys/dev/hwt/hwt_event.c
@@ -1,8 +1,7 @@
 /*-
- * Copyright (c) 2023 Ruslan Bukin <br@bsdpad.com>
+ * SPDX-License-Identifier: BSD-2-Clause
  *
- * This work was supported by Innovate UK project 105694, "Digital Security
- * by Design (DSbD) Technology Platform Prototype".
+ * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,42 +23,50 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * $FreeBSD$
  */
 
-#ifndef _DEV_HWT_HWT_THREAD_H_
-#define _DEV_HWT_HWT_THREAD_H_
+#include <sys/param.h>
+#include <sys/kernel.h>
+#include <sys/event.h>
+#include <sys/queue.h>
+#include <sys/malloc.h>
+#include <sys/taskqueue.h>
 
-struct hwt_record_entry;
+#include <dev/hwt/hwt_context.h>
 
-struct hwt_thread {
-	struct hwt_vm			*vm;
-	struct hwt_context		*ctx;
-	struct thread			*td;
-	TAILQ_ENTRY(hwt_thread)		next;
-	int				thread_id;
-	int				state;
-#define	HWT_THREAD_STATE_EXITED		(1 << 0)
-	struct mtx			mtx;
-	u_int				refcnt;
-	int				cpu_id; /* last cpu_id */
-	void				*cookie; /* backend-specific private data */
-};
+#include "hwt_event.h"
 
-/* Thread allocation. */
-int hwt_thread_alloc(struct hwt_context *ctx, struct hwt_thread **thr0, char *path, size_t bufsize,
-    int kva_req);
-void hwt_thread_free(struct hwt_thread *thr);
+TASKQUEUE_FAST_DEFINE_THREAD(hwt);
 
-/* Thread list mgt. */
-void hwt_thread_insert(struct hwt_context *ctx, struct hwt_thread *thr, struct hwt_record_entry *entry);
-struct hwt_thread * hwt_thread_first(struct hwt_context *ctx);
-struct hwt_thread * hwt_thread_lookup(struct hwt_context *ctx,
-    struct thread *td);
+static void
+hwt_event_record_handler(void *arg, int pending __unused)
+{
+        int ret __diagused;
+        struct kevent kev;
+        struct hwt_context *ctx = (struct hwt_context *)arg;
 
-#define	HWT_THR_LOCK(thr)		mtx_lock(&(thr)->mtx)
-#define	HWT_THR_UNLOCK(thr)		mtx_unlock(&(thr)->mtx)
-#define	HWT_THR_ASSERT_LOCKED(thr)	mtx_assert(&(thr)->mtx, MA_OWNED)
+        EV_SET(&kev, HWT_KQ_NEW_RECORD_EV, EVFILT_USER, EV_ENABLE, NOTE_TRIGGER, 0, NULL);
+        ret = kqfd_register(ctx->kqueue_fd, &kev, ctx->hwt_td, M_WAITOK);
+        KASSERT(ret == 0,
+                ("%s: kqueue fd register failed: %d\n", __func__, ret));
+}
 
-#endif /* !_DEV_HWT_HWT_THREAD_H_ */
+
+int
+hwt_event_send(int ev_type, struct task *task, task_fn_t *handler, void *ctx)
+{
+        int error;
+        /* TODO: validate event type - EINVAL */
+        if(ev_type == HWT_KQ_NEW_RECORD_EV){
+                handler = hwt_event_record_handler;
+        }
+        TASK_INIT(task, 0, handler, ctx);
+        error = taskqueue_enqueue(taskqueue_hwt, task);
+
+        return (error);
+}
+
+void
+hwt_event_drain_all(void){
+        taskqueue_drain_all(taskqueue_hwt);
+}

--- a/sys/dev/hwt/hwt_event.h
+++ b/sys/dev/hwt/hwt_event.h
@@ -1,8 +1,6 @@
 /*-
- * Copyright (c) 2023 Ruslan Bukin <br@bsdpad.com>
- *
- * This work was supported by Innovate UK project 105694, "Digital Security
- * by Design (DSbD) Technology Platform Prototype".
+ * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
+ * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -24,42 +22,22 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
- * $FreeBSD$
  */
 
-#ifndef _DEV_HWT_HWT_THREAD_H_
-#define _DEV_HWT_HWT_THREAD_H_
+#ifndef _DEV_HWT_HWT_EVENT_H_
+#define _DEV_HWT_HWT_EVENT_H_
 
-struct hwt_record_entry;
+/* HWT event delivery flags and values. */
+#define HWT_KQ_BUFRDY_EV 138
+#define HWT_KQ_NEW_RECORD_EV 139
 
-struct hwt_thread {
-	struct hwt_vm			*vm;
-	struct hwt_context		*ctx;
-	struct thread			*td;
-	TAILQ_ENTRY(hwt_thread)		next;
-	int				thread_id;
-	int				state;
-#define	HWT_THREAD_STATE_EXITED		(1 << 0)
-	struct mtx			mtx;
-	u_int				refcnt;
-	int				cpu_id; /* last cpu_id */
-	void				*cookie; /* backend-specific private data */
-};
+#define HWT_KQ_BUFRDY_ID_MASK		0xFFFF
 
-/* Thread allocation. */
-int hwt_thread_alloc(struct hwt_context *ctx, struct hwt_thread **thr0, char *path, size_t bufsize,
-    int kva_req);
-void hwt_thread_free(struct hwt_thread *thr);
+#ifdef _KERNEL
+struct task;
 
-/* Thread list mgt. */
-void hwt_thread_insert(struct hwt_context *ctx, struct hwt_thread *thr, struct hwt_record_entry *entry);
-struct hwt_thread * hwt_thread_first(struct hwt_context *ctx);
-struct hwt_thread * hwt_thread_lookup(struct hwt_context *ctx,
-    struct thread *td);
+int hwt_event_send(int ev_type, struct task *task, task_fn_t *handler, void *ctx);
+void hwt_event_drain_all(void);
 
-#define	HWT_THR_LOCK(thr)		mtx_lock(&(thr)->mtx)
-#define	HWT_THR_UNLOCK(thr)		mtx_unlock(&(thr)->mtx)
-#define	HWT_THR_ASSERT_LOCKED(thr)	mtx_assert(&(thr)->mtx, MA_OWNED)
-
-#endif /* !_DEV_HWT_HWT_THREAD_H_ */
+#endif
+#endif /* !_DEV_HWT_HWT_EVENT_H_ */

--- a/sys/dev/hwt/hwt_hook.c
+++ b/sys/dev/hwt/hwt_hook.c
@@ -235,7 +235,7 @@ hwt_hook_thread_create(struct thread *td)
 	hwt_ctx_put(ctx);
 
 	/* Step 2. Allocate some memory without holding ctx ref. */
-	error = hwt_thread_alloc(&thr, path, bufsize, kva_req);
+	error = hwt_thread_alloc(ctx, &thr, path, bufsize, kva_req);
 	if (error) {
 		printf("%s: could not allocate thread, error %d\n",
 		    __func__, error);
@@ -261,13 +261,15 @@ hwt_hook_thread_create(struct thread *td)
 	thr->td = td;
 
 	HWT_CTX_LOCK(ctx);
-	TAILQ_INSERT_TAIL(&ctx->threads, thr, next);
-	LIST_INSERT_HEAD(&ctx->records, entry, next);
+	hwt_thread_insert(ctx, thr, entry);
 	HWT_CTX_UNLOCK(ctx);
+
+	/* Notify userspace. */
+	hwt_event_send(HWT_KQ_NEW_RECORD_EV, &entry->task, NULL, (void *)ctx);
 
 	hwt_ctx_put(ctx);
 
-	return (0);
+	return (error);
 }
 
 static void

--- a/sys/dev/hwt/hwt_vm.c
+++ b/sys/dev/hwt/hwt_vm.c
@@ -201,6 +201,7 @@ hwt_vm_mmap_single(struct cdev *cdev, vm_ooffset_t *offset,
 	if (nprot != PROT_READ || *offset != 0)
 		return (ENXIO);
 
+	vm_object_reference(vm->obj);
 	*objp = vm->obj;
 
 	return (0);
@@ -224,9 +225,10 @@ hwt_vm_start_cpu_mode(struct hwt_context *ctx)
 			hwt_backend_enable(ctx, cpu_id);
 	}
 
-	/* Some backends required enabling all CPUs at once. */
-	if (ctx->hwt_backend->ops->hwt_backend_enable_smp != NULL)
+	/* Some backends require enabling all CPUs at once. */
+	if(ctx->hwt_backend->ops->hwt_backend_enable_smp != NULL){
 		hwt_backend_enable_smp(ctx);
+	}
 }
 
 static int
@@ -438,6 +440,7 @@ hwt_vm_destroy_buffers(struct hwt_vm *vm)
 void
 hwt_vm_free(struct hwt_vm *vm)
 {
+	dprintf("%s\n", __func__);
 
 	if (vm->cdev)
 		destroy_dev_sched(vm->cdev);

--- a/sys/sys/hwt.h
+++ b/sys/sys/hwt.h
@@ -34,6 +34,7 @@
 #include <sys/cpuset.h>
 #include <sys/types.h>
 #include <sys/hwt_record.h>
+#include <dev/hwt/hwt_event.h>
 
 #ifndef _SYS_HWT_H_
 #define _SYS_HWT_H_

--- a/sys/sys/hwt_record.h
+++ b/sys/sys/hwt_record.h
@@ -44,12 +44,15 @@ enum hwt_record_type {
 };
 
 #ifdef _KERNEL
+#include <sys/taskqueue.h>
+
 struct hwt_record_entry {
 	enum hwt_record_type		record_type;
 	LIST_ENTRY(hwt_record_entry)	next;
 	char				*fullpath;
 	int				thread_id;
 	uintptr_t			addr;
+	struct task			task;
 };
 #endif
 

--- a/sys/x86/include/apicvar.h
+++ b/sys/x86/include/apicvar.h
@@ -232,6 +232,7 @@ int	lapic_enable_mca_elvt(void);
 void	lapic_ipi_raw(register_t icrlo, u_int dest);
 void 	lapic_enable_pt_pmi(void);
 void 	lapic_disable_pt_pmi(void);
+void	lapic_reenable_pt_pmi(void);
 
 static inline void
 lapic_ipi_vectored(u_int vector, int dest)

--- a/sys/x86/x86/local_apic.c
+++ b/sys/x86/x86/local_apic.c
@@ -822,10 +822,22 @@ lapic_reenable_pmc(void)
 }
 
 #ifdef HWT_HOOKS
+
+void
+lapic_reenable_pt_pmi(void)
+{
+	uint32_t value;
+
+	value = lapic_read32(LAPIC_LVT_PCINT);
+	value &= ~APIC_LVT_M;
+	lapic_write32(LAPIC_LVT_PCINT, value);
+}
+
 void
 lapic_enable_pt_pmi(void)
 {
         uint32_t value = 0;
+
         value |= APIC_LVT_DM_NMI;
         lapic_write32(LAPIC_LVT_PCINT, value);
 }
@@ -839,7 +851,6 @@ lapic_disable_pt_pmi(void)
         value |= APIC_LVT_M;
         lapic_write32(LAPIC_LVT_PCINT, value);
 }
-
 #endif
 
 

--- a/usr.sbin/hwt/Makefile
+++ b/usr.sbin/hwt/Makefile
@@ -3,7 +3,7 @@
 PROG_CXX=	hwt
 MAN=
 
-CFLAGS+= -I${SRCTOP}/lib/libpmcstat
+CFLAGS+= -I${SRCTOP}/lib/libpmcstat -I${SRCTOP}/sys
 
 LIBADD= elf pmcstat xo util
 

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -36,7 +36,8 @@ struct trace_context;
 
 struct trace_dev_methods {
 	int (*init)(struct trace_context *tc);
-	int (*mmap)(struct trace_context *tc);
+	int (*mmap)(struct trace_context *tc,
+	    struct hwt_record_user_entry *entry);
 	int (*process)(struct trace_context *tc);
 	int (*set_config)(struct trace_context *tc);
 };

--- a/usr.sbin/hwt/hwt_record.c
+++ b/usr.sbin/hwt/hwt_record.c
@@ -158,6 +158,11 @@ hwt_record_fetch(struct trace_context *tc, int *nrecords)
 			pmcstat_image_link(tc->pp, image, addr);
 			break;
 		case HWT_RECORD_THREAD_CREATE:
+			/* Let the backend register the newly created thread. */
+			if ((error = tc->trace_dev->methods->mmap(tc, entry)) !=
+			    0)
+				return error;
+			break;
 		case HWT_RECORD_THREAD_SET_NAME:
 			break;
 		default:


### PR DESCRIPTION
This patch implements MODE_THREAD for the Intel PT backend, along with several fixes for MODE_CPU.
The userspace backend has been fully adapted to a `kevent`-based workflow and can now manage tracing buffers dynamically.
Packet decoding is still limited and will terminate tracing prematurely, so I recommend using raw tracing for testing purposes.

Implementing MODE_THREAD for PT required some modifications to the HWT code:
- `struct hwt_thread` now allows backend to register a 'cookie'; an opaque pointer for backend-specific data. PT uses this to associate its software context with a particular thread.
- backend ops were expanded with a alloc/free function for the aforementioned data
- a `hwt_event` subsystem was added to simplify sending events to userspace
- HWT now inserts thread creation records in the hook handler and when creating a new process
- `hwt_record_fetch` will call the backend's `mmap` routine whenever a `HWT_RECORD_THREAD_CREATE` record is encountered. Backends can use this to register and map trace buffers for new threads