### PR TITLE
hwt: Rename backend thread ops and fix PT SDT issues

### DIFF
--- a/sys/amd64/pt/pt.c
+++ b/sys/amd64/pt/pt.c
@@ -77,7 +77,7 @@
 
 MALLOC_DEFINE(M_PT, "pt", "Intel Processor Trace");
 
-SDT_PROVIDER_DECLARE(pt);
+SDT_PROVIDER_DEFINE(pt);
 SDT_PROBE_DEFINE(pt, , , topa__intr);
 
 static bool loaded = false;

--- a/sys/amd64/pt/pt.c
+++ b/sys/amd64/pt/pt.c
@@ -477,9 +477,9 @@ pt_backend_configure(struct hwt_context *ctx, int cpu_id, int thread_id)
 		TAILQ_FOREACH (thr, &ctx->threads, next) {
 			if (thr->thread_id != thread_id)
 				continue;
-			KASSERT(thr->cookie != NULL, ("%s: hwt thread cookie "
-			    "not set, thr %p", __func__, thr));
-			pt_ctx = (struct pt_ctx *)thr->cookie;
+			KASSERT(thr->private != NULL, ("%s: hwt thread private"
+			    " not set, thr %p", __func__, thr));
+			pt_ctx = (struct pt_ctx *)thr->private;
 			break;
 		}
 	}
@@ -620,9 +620,9 @@ pt_backend_deinit(struct hwt_context *ctx)
 	hwt_event_drain_all();
 	if (ctx->mode == HWT_MODE_THREAD) {
 		TAILQ_FOREACH (thr, &ctx->threads, next) {
-			KASSERT(thr->cookie != NULL,
-			    ("%s: thr->cookie not set", __func__));
-			pt_ctx = (struct pt_ctx *)thr->cookie;
+			KASSERT(thr->private != NULL,
+			    ("%s: thr->private not set", __func__));
+			pt_ctx = (struct pt_ctx *)thr->private;
 			/* Free ToPA table. */
 			pt_deinit_ctx(pt_ctx);
 		}
@@ -656,7 +656,7 @@ pt_backend_read(int cpu_id, int *curpage, vm_offset_t *curpage_offset)
 }
 
 static int
-pt_backend_alloc_thread_priv(struct hwt_thread *thr)
+pt_backend_alloc_thread(struct hwt_thread *thr)
 {
 	struct pt_ctx *pt_ctx;
 	int error;
@@ -670,16 +670,16 @@ pt_backend_alloc_thread_priv(struct hwt_thread *thr)
 	if (error)
 		return error;
 
-	thr->cookie = pt_ctx;
+	thr->private = pt_ctx;
 	return (0);
 }
 
 static void
-pt_backend_free_thread_priv(struct hwt_thread *thr)
+pt_backend_free_thread(struct hwt_thread *thr)
 {
 	struct pt_ctx *ctx;
 
-	ctx = (struct pt_ctx *)thr->cookie;
+	ctx = (struct pt_ctx *)thr->private;
 
 	pt_deinit_ctx(ctx);
 	free(ctx, M_PT);
@@ -707,8 +707,8 @@ static struct hwt_backend_ops pt_ops = {
 	.hwt_backend_read = pt_backend_read,
 	.hwt_backend_dump = pt_backend_dump,
 
-	.hwt_backend_alloc_thread_priv = pt_backend_alloc_thread_priv,
-	.hwt_backend_free_thread_priv = pt_backend_free_thread_priv,
+	.hwt_backend_thread_alloc = pt_backend_alloc_thread,
+	.hwt_backend_thread_free = pt_backend_free_thread,
 };
 
 static struct hwt_backend backend = {

--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -262,3 +262,33 @@ hwt_backend_svc_buf(struct hwt_context *ctx, int cpu_id)
 
 	return (error);
 }
+
+int
+hwt_backend_thread_alloc(struct hwt_context *ctx, struct hwt_thread *thr)
+{
+	int error;
+
+	dprintf("%s\n", __func__);
+
+	if (ctx->hwt_backend->ops->hwt_backend_thread_alloc == NULL)
+		return (0);
+	KASSERT(thr->private == NULL,
+		    ("%s: thread private data is not NULL\n", __func__));
+	error = ctx->hwt_backend->ops->hwt_backend_thread_alloc(thr);
+
+	return (error);
+}
+
+void
+hwt_backend_thread_free(struct hwt_thread *thr)
+{
+	dprintf("%s\n", __func__);
+
+	if (thr->ctx->hwt_backend->ops->hwt_backend_thread_free == NULL)
+		return;
+	KASSERT(thr->private != NULL,
+		    ("%s: thread private data is NULL\n", __func__));
+	thr->ctx->hwt_backend->ops->hwt_backend_thread_free(thr);
+
+	return;
+}

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -46,8 +46,8 @@ struct hwt_backend_ops {
 	void (*hwt_backend_enable_smp)(struct hwt_context *);
 	void (*hwt_backend_disable_smp)(struct hwt_context *);
 	/* Allocation and initialization of backend-specific thread data. */
-	int (*hwt_backend_alloc_thread_priv)(struct hwt_thread *);
-	void (*hwt_backend_free_thread_priv)(struct hwt_thread *);
+	int (*hwt_backend_thread_alloc)(struct hwt_thread *);
+	void (*hwt_backend_thread_free)(struct hwt_thread *);
 	/* Debugging only. */
 	void (*hwt_backend_dump)(int cpu_id);
 };
@@ -72,6 +72,8 @@ int hwt_backend_unregister(struct hwt_backend *);
 void hwt_backend_stop(struct hwt_context *);
 int hwt_backend_svc_buf(struct hwt_context *ctx, int cpu_id);
 struct hwt_backend * hwt_backend_lookup(const char *name);
+int hwt_backend_thread_alloc(struct hwt_context *ctx, struct hwt_thread *);
+void hwt_backend_thread_free(struct hwt_thread *);
 
 void hwt_backend_load(void);
 void hwt_backend_unload(void);

--- a/sys/dev/hwt/hwt_hook.c
+++ b/sys/dev/hwt/hwt_hook.c
@@ -256,10 +256,11 @@ hwt_hook_thread_create(struct thread *td)
 		return (ENXIO);
 	}
 	/* Allocate backend-specific thread data. */
-	if (hwt_backend_thread_alloc(ctx, thr) != 0) {
+	error = hwt_backend_thread_alloc(ctx, thr);
+	if (error != 0) {
 		dprintf("%s: failed to allocate backend thread data\n",
 			    __func__);
-		return (ENOMEM);
+		return (error);
 	}
 
 	thr->vm->ctx = ctx;

--- a/sys/dev/hwt/hwt_hook.c
+++ b/sys/dev/hwt/hwt_hook.c
@@ -255,6 +255,12 @@ hwt_hook_thread_create(struct thread *td)
 		/* ctx->thread_counter does not matter. */
 		return (ENXIO);
 	}
+	/* Allocate backend-specific thread data. */
+	if (hwt_backend_thread_alloc(ctx, thr) != 0) {
+		dprintf("%s: failed to allocate backend thread data\n",
+			    __func__);
+		return (ENOMEM);
+	}
 
 	thr->vm->ctx = ctx;
 	thr->ctx = ctx;

--- a/sys/dev/hwt/hwt_hook.c
+++ b/sys/dev/hwt/hwt_hook.c
@@ -236,7 +236,7 @@ hwt_hook_thread_create(struct thread *td)
 	hwt_ctx_put(ctx);
 
 	/* Step 2. Allocate some memory without holding ctx ref. */
-	error = hwt_thread_alloc(ctx, &thr, path, bufsize, kva_req);
+	error = hwt_thread_alloc(&thr, path, bufsize, kva_req);
 	if (error) {
 		printf("%s: could not allocate thread, error %d\n",
 		    __func__, error);

--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -213,7 +213,7 @@ hwt_ioctl_alloc_mode_thread(struct thread *td, struct hwt_owner *ho,
 		thread_id = atomic_fetchadd_int(&ctx->thread_counter, 1);
 		sprintf(path, "hwt_%d_%d", ctx->ident, thread_id);
 
-		error = hwt_thread_alloc(ctx, &thr, path, ctx->bufsize,
+		error = hwt_thread_alloc(&thr, path, ctx->bufsize,
 		    ctx->kva_req);
 		if (error) {
 			free(threads, M_HWT_IOCTL);

--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -221,12 +221,13 @@ hwt_ioctl_alloc_mode_thread(struct thread *td, struct hwt_owner *ho,
 			return (error);
 		}
 		/* Allocate backend-specific thread data. */
-		if (hwt_backend_thread_alloc(ctx, thr) != 0) {
+		error = hwt_backend_thread_alloc(ctx, thr);
+		if (error != 0) {
 			dprintf("%s: failed to allocate thread backend data\n",
 			    __func__);
 			free(threads, M_HWT_IOCTL);
 			hwt_ctx_free(ctx);
-			return (ENOMEM);
+			return (error);
 		}
 
 		/*

--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -220,6 +220,15 @@ hwt_ioctl_alloc_mode_thread(struct thread *td, struct hwt_owner *ho,
 			hwt_ctx_free(ctx);
 			return (error);
 		}
+		/* Allocate backend-specific thread data. */
+		if (hwt_backend_thread_alloc(ctx, thr) != 0) {
+			dprintf("%s: failed to allocate thread backend data\n",
+			    __func__);
+			free(threads, M_HWT_IOCTL);
+			hwt_ctx_free(ctx);
+			return (ENOMEM);
+		}
+
 		/*
 		 * Insert a THREAD_CREATE record so userspace picks up
 		 * the thread's tracing buffers.

--- a/sys/dev/hwt/hwt_thread.c
+++ b/sys/dev/hwt/hwt_thread.c
@@ -115,7 +115,7 @@ hwt_thread_lookup(struct hwt_context *ctx, struct thread *td)
 }
 
 int
-hwt_thread_alloc(struct hwt_context *ctx, struct hwt_thread **thr0, char *path, size_t bufsize,
+hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize,
     int kva_req)
 {
 	struct hwt_thread *thr;

--- a/sys/dev/hwt/hwt_thread.h
+++ b/sys/dev/hwt/hwt_thread.h
@@ -44,7 +44,7 @@ struct hwt_thread {
 	struct mtx			mtx;
 	u_int				refcnt;
 	int				cpu_id; /* last cpu_id */
-	void				*cookie; /* backend-specific private data */
+	void				*private; /* backend-specific private data */
 };
 
 /* Thread allocation. */

--- a/sys/dev/hwt/hwt_thread.h
+++ b/sys/dev/hwt/hwt_thread.h
@@ -48,7 +48,7 @@ struct hwt_thread {
 };
 
 /* Thread allocation. */
-int hwt_thread_alloc(struct hwt_context *ctx, struct hwt_thread **thr0, char *path, size_t bufsize,
+int hwt_thread_alloc(struct hwt_thread **thr0, char *path, size_t bufsize,
     int kva_req);
 void hwt_thread_free(struct hwt_thread *thr);
 


### PR DESCRIPTION
I've fixed the SDT issue, renamed the thread allocation ops (as per @zdleaf's suggestion), and fixed the ctx lifetime issue in hwt_hook that we discussed today.