### PR TITLE
hwt: zero cpu_map to avoid uninitialised data

### DIFF
--- a/sys/dev/hwt/hwt_ioctl.c
+++ b/sys/dev/hwt/hwt_ioctl.c
@@ -277,20 +277,17 @@ hwt_ioctl_alloc_mode_cpu(struct thread *td, struct hwt_owner *ho,
 	char path[MAXPATHLEN];
 	size_t cpusetsize;
 	cpuset_t cpu_map;
-	int cpu_count;
+	int cpu_count = 0;
 	int cpu_id;
 	int error;
 
-	cpu_count = 0;
-
+	CPU_ZERO(&cpu_map);
 	cpusetsize = min(halloc->cpusetsize, sizeof(cpuset_t));
 	error = copyin(halloc->cpu_map, &cpu_map, cpusetsize);
 	if (error)
 		return (error);
 
-	CPU_FOREACH(cpu_id) {
-		if (!CPU_ISSET(cpu_id, &cpu_map))
-			continue;
+	CPU_FOREACH_ISSET(cpu_id, &cpu_map) {
 		/* Ensure CPU is not halted. */
 		if (CPU_ISSET(cpu_id, &hlt_cpus_mask))
 			return (ENXIO);
@@ -325,10 +322,7 @@ hwt_ioctl_alloc_mode_cpu(struct thread *td, struct hwt_owner *ho,
 		return (error);
 	}
 
-	CPU_FOREACH(cpu_id) {
-		if (!CPU_ISSET(cpu_id, &cpu_map))
-			continue;
-
+	CPU_FOREACH_ISSET(cpu_id, &cpu_map) {
 		sprintf(path, "hwt_%d_%d", ctx->ident, cpu_id);
 		error = hwt_vm_alloc(ctx->bufsize, ctx->kva_req, path, &vm);
 		if (error) {

--- a/sys/dev/hwt/hwt_vm.c
+++ b/sys/dev/hwt/hwt_vm.c
@@ -212,10 +212,7 @@ hwt_vm_start_cpu_mode(struct hwt_context *ctx)
 {
 	int cpu_id;
 
-	CPU_FOREACH(cpu_id) {
-		if (!CPU_ISSET(cpu_id, &ctx->cpu_map))
-			continue;
-
+	CPU_FOREACH_ISSET(cpu_id, &ctx->cpu_map) {
 		/* Ensure CPU is not halted. */
 		if (CPU_ISSET(cpu_id, &hlt_cpus_mask))
 			return;


### PR DESCRIPTION
When kernel sizeof(cpuset_t) is greater than the size passed in from userspace, we can end up using uninitialised junk in the end of larger kernel map. This is likely to happen now CPU_MAXSIZE has been bumped to 1024 but userspace is still using the smaller 256 value.

Ensure we zero out &cpu_map to prevent this from happening.

At the same time simplify to using CPU_FOREACH_ISSET() to save a few lines.