### PR TITLE
hwt: Add PT decoder

### DIFF
--- a/sys/dev/hwt/hwt_backend.c
+++ b/sys/dev/hwt/hwt_backend.c
@@ -149,14 +149,14 @@ hwt_backend_dump(struct hwt_context *ctx, int cpu_id)
 }
 
 int
-hwt_backend_read(struct hwt_context *ctx, int cpu_id, int *curpage,
+hwt_backend_read(struct hwt_context *ctx, struct hwt_vm *vm, int *curpage,
     vm_offset_t *curpage_offset)
 {
 	int error;
 
 	dprintf("%s\n", __func__);
 
-	error = ctx->hwt_backend->ops->hwt_backend_read(cpu_id, curpage,
+	error = ctx->hwt_backend->ops->hwt_backend_read(vm, curpage,
 	    curpage_offset);
 
 	return (error);

--- a/sys/dev/hwt/hwt_backend.h
+++ b/sys/dev/hwt/hwt_backend.h
@@ -39,7 +39,7 @@ struct hwt_backend_ops {
 	int (*hwt_backend_svc_buf)(struct hwt_context *, int cpu_id);
 	void (*hwt_backend_enable)(struct hwt_context *, int cpu_id);
 	void (*hwt_backend_disable)(struct hwt_context *, int cpu_id);
-	int (*hwt_backend_read)(int cpu_id, int *curpage,
+	int (*hwt_backend_read)(struct hwt_vm *, int *curpage,
 	    vm_offset_t *curpage_offset);
 	void (*hwt_backend_stop)(struct hwt_context *);
 	/* For backends that are tied to local CPU registers */
@@ -65,7 +65,7 @@ void hwt_backend_disable(struct hwt_context *ctx, int cpu_id);
 void hwt_backend_enable_smp(struct hwt_context *ctx);
 void hwt_backend_disable_smp(struct hwt_context *ctx);
 void hwt_backend_dump(struct hwt_context *ctx, int cpu_id);
-int hwt_backend_read(struct hwt_context *ctx, int cpu_id, int *curpage,
+int hwt_backend_read(struct hwt_context *ctx, struct hwt_vm *vm, int *curpage,
     vm_offset_t *curpage_offset);
 int hwt_backend_register(struct hwt_backend *);
 int hwt_backend_unregister(struct hwt_backend *);

--- a/sys/dev/hwt/hwt_context.c
+++ b/sys/dev/hwt/hwt_context.c
@@ -101,7 +101,7 @@ hwt_ctx_alloc(struct hwt_context **ctx0)
 	ctx->thread_counter = 0;
 	ctx->kva_req = 1; /* default require kern VAs */
 
-	LIST_INIT(&ctx->records);
+	TAILQ_INIT(&ctx->records);
 	TAILQ_INIT(&ctx->threads);
 	TAILQ_INIT(&ctx->cpus);
 	mtx_init(&ctx->mtx, "ctx", NULL, MTX_SPIN);

--- a/sys/dev/hwt/hwt_context.h
+++ b/sys/dev/hwt/hwt_context.h
@@ -37,7 +37,7 @@ enum hwt_ctx_state {
 };
 
 struct hwt_context {
-	LIST_HEAD(, hwt_record_entry)	records;
+	TAILQ_HEAD(, hwt_record_entry)	records;
 
 	LIST_ENTRY(hwt_context)		next_hch; /* Entry in contexthash. */
 	LIST_ENTRY(hwt_context)		next_hwts; /* Entry in ho->hwts. */

--- a/sys/dev/hwt/hwt_record.c
+++ b/sys/dev/hwt/hwt_record.c
@@ -83,7 +83,7 @@ hwt_record(struct thread *td, struct hwt_record_entry *ent)
 		return;
 	}
 	HWT_CTX_LOCK(ctx);
-	LIST_INSERT_HEAD(&ctx->records, entry, next);
+	TAILQ_INSERT_TAIL(&ctx->records, entry, next);
 	HWT_CTX_UNLOCK(ctx);
 
 	hwt_ctx_put(ctx);
@@ -116,9 +116,9 @@ hwt_record_grab(struct hwt_context *ctx,
 
 	for (i = 0; i < nitems_req; i++) {
 		HWT_CTX_LOCK(ctx);
-		entry = LIST_FIRST(&ctx->records);
+		entry = TAILQ_FIRST(&ctx->records);
 		if (entry)
-			LIST_REMOVE(entry, next);
+			TAILQ_REMOVE_HEAD(&ctx->records, next);
 		HWT_CTX_UNLOCK(ctx);
 
 		if (entry == NULL)
@@ -146,9 +146,9 @@ hwt_record_free_all(struct hwt_context *ctx)
 
 	while (1) {
 		HWT_CTX_LOCK(ctx);
-		entry = LIST_FIRST(&ctx->records);
+		entry = TAILQ_FIRST(&ctx->records);
 		if (entry)
-			LIST_REMOVE(entry, next);
+			TAILQ_REMOVE_HEAD(&ctx->records, next);
 		HWT_CTX_UNLOCK(ctx);
 
 		if (entry == NULL)
@@ -210,7 +210,7 @@ hwt_record_kernel_objects(struct hwt_context *ctx)
 		entry->addr = kobase[i].pm_address;
 
 		HWT_CTX_LOCK(ctx);
-		LIST_INSERT_HEAD(&ctx->records, entry, next);
+		TAILQ_INSERT_HEAD(&ctx->records, entry, next);
 		HWT_CTX_UNLOCK(ctx);
 	}
 	free(kobase, M_LINKER);

--- a/sys/dev/hwt/hwt_thread.c
+++ b/sys/dev/hwt/hwt_thread.c
@@ -162,5 +162,5 @@ hwt_thread_insert(struct hwt_context *ctx, struct hwt_thread *thr,
 
 	HWT_CTX_ASSERT_LOCKED(ctx);
 	TAILQ_INSERT_TAIL(&ctx->threads, thr, next);
-	LIST_INSERT_HEAD(&ctx->records, entry, next);
+	TAILQ_INSERT_TAIL(&ctx->records, entry, next);
 }

--- a/sys/dev/hwt/hwt_vm.c
+++ b/sys/dev/hwt/hwt_vm.c
@@ -318,12 +318,7 @@ hwt_vm_ioctl(struct cdev *dev, u_long cmd, caddr_t addr, int flags,
 	case HWT_IOC_BUFPTR_GET:
 		ptr_get = (struct hwt_bufptr_get *)addr;
 
-		if (ctx->mode == HWT_MODE_THREAD)
-			cpu_id = vm->thr->cpu_id;
-		else
-			cpu_id = vm->cpu->cpu_id;
-
-		error = hwt_backend_read(ctx, cpu_id, &curpage,
+		error = hwt_backend_read(ctx, vm, &curpage,
 		    &curpage_offset);
 		if (error)
 			return (error);

--- a/sys/sys/hwt_record.h
+++ b/sys/sys/hwt_record.h
@@ -48,7 +48,7 @@ enum hwt_record_type {
 
 struct hwt_record_entry {
 	enum hwt_record_type		record_type;
-	LIST_ENTRY(hwt_record_entry)	next;
+	TAILQ_ENTRY(hwt_record_entry)	next;
 	char				*fullpath;
 	int				thread_id;
 	uintptr_t			addr;

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -53,9 +53,11 @@
 
 #include "libpmcstat_stubs.h"
 #include <libpmcstat.h>
+#include <libgen.h>
 #include <libxo/xo.h>
 
 #include "hwt.h"
+#include "hwt_elf.h"
 
 #if defined(__aarch64__)
 #include "hwt_coresight.h"

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -630,7 +630,10 @@ main(int argc, char **argv, char **env)
 			 * Name of dynamic lib or main executable for IP
 			 * address range filtering.
 			 */
-			tc->image_name = strdup(optarg);
+			tc->image_name = strdup(basename(optarg));
+			if (*tc->image_name == '.' || *tc->image_name == '/')
+				err(EX_USAGE,
+				    "Invalid executable path provided");
 			break;
 		case 'f':
 			/* Name of the func to trace. */

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -223,6 +223,34 @@ hwt_get_records(struct trace_context *tc, uint32_t *nrec)
 	return (0);
 }
 
+struct pmcstat_symbol *
+hwt_sym_lookup(const struct trace_context *tc, uint64_t ip,
+    struct pmcstat_image **img, uint64_t *newpc0)
+{
+	struct pmcstat_image *image;
+	struct pmcstat_symbol *sym;
+	struct pmcstat_pcmap *map;
+	uint64_t newpc;
+
+	map = pmcstat_process_find_map(tc->pp, ip);
+	if (map != NULL) {
+		image = map->ppm_image;
+		newpc = ip -
+		    ((unsigned long)map->ppm_lowpc +
+			(image->pi_vaddr - image->pi_start));
+		sym = pmcstat_symbol_search(image, newpc); /* Could be NULL. */
+		newpc += image->pi_vaddr;
+
+		*img = image;
+		*newpc0 = newpc;
+
+		return (sym);
+	} else
+		*img = NULL;
+
+	return (NULL);
+}
+
 int
 hwt_find_sym(struct trace_context *tc)
 {

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -33,6 +33,7 @@
 #define	TC_MAX_ADDR_RANGES	16
 
 struct trace_context;
+struct hwt_exec_img;
 
 struct trace_dev_methods {
 	int (*init)(struct trace_context *tc);
@@ -93,7 +94,6 @@ int hwt_process_start(int *sockpair);
 int hwt_record_fetch(struct trace_context *tc, int *nrecords);
 void hwt_procexit(pid_t pid, int status);
 void hwt_sleep(int msec);
-int hwt_elf_count_libs(const char *elf_path, uint32_t *nlibs0);
 int hwt_find_sym(struct trace_context *tc);
 int hwt_start_tracing(struct trace_context *tc);
 int hwt_stop_tracing(struct trace_context *tc);

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -34,6 +34,7 @@
 
 struct trace_context;
 struct hwt_exec_img;
+struct pmcstat_image;
 
 struct trace_dev_methods {
 	int (*init)(struct trace_context *tc);
@@ -41,6 +42,8 @@ struct trace_dev_methods {
 	    struct hwt_record_user_entry *entry);
 	int (*process)(struct trace_context *tc);
 	int (*set_config)(struct trace_context *tc);
+	int (
+	    *image_load_cb)(struct trace_context *tc, struct hwt_exec_img *img);
 };
 
 struct trace_dev {
@@ -95,6 +98,8 @@ int hwt_record_fetch(struct trace_context *tc, int *nrecords);
 void hwt_procexit(pid_t pid, int status);
 void hwt_sleep(int msec);
 int hwt_find_sym(struct trace_context *tc);
+struct pmcstat_symbol *hwt_sym_lookup(const struct trace_context *tc,
+    uint64_t ip, struct pmcstat_image **img, uint64_t *newpc0);
 int hwt_start_tracing(struct trace_context *tc);
 int hwt_stop_tracing(struct trace_context *tc);
 int hwt_mmap_received(struct trace_context *tc,

--- a/usr.sbin/hwt/hwt_elf.h
+++ b/usr.sbin/hwt/hwt_elf.h
@@ -1,0 +1,45 @@
+/*-
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Copyright (c) 2024 Bojan Novković <bnovkov@freebsd.org>
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef HWT_ELF_H_
+#define HWT_ELF_H_
+
+/*
+ * Metadata for the .text loaded from executable
+ * 'path' into the traced process's address space.
+ */
+struct hwt_exec_img {
+	size_t size;
+	uint64_t offs;
+	uint64_t addr;
+	const char *path;
+};
+
+int hwt_elf_count_libs(const char *elf_path, uint32_t *nlibs0);
+int hwt_elf_get_text_offs(const char *elf_path, uint64_t *offs);
+
+#endif /* HWT_ELF_H_ */

--- a/usr.sbin/hwt/hwt_process.c
+++ b/usr.sbin/hwt/hwt_process.c
@@ -89,7 +89,7 @@ hwt_process_create(int *sockpair, char **cmd, char **env __unused, int *pid0)
 		return (-1);
 
 	signal(SIGCHLD, hwt_process_onsig);
-
+	siginterrupt(SIGCHLD, 1);
 	pid = fork();
 
 	switch (pid) {

--- a/usr.sbin/hwt/hwt_pt.c
+++ b/usr.sbin/hwt/hwt_pt.c
@@ -44,14 +44,18 @@
 #include <assert.h>
 #include <signal.h>
 #include <fcntl.h>
+#include <unistd.h>
 
 #include "amd64/pt/pt.h"
 #include "dev/hwt/hwt_event.h"
 #include "hwt.h"
+#include "hwt_elf.h"
 #include "hwt_pt.h"
-#include "sys/_stdint.h"
-#include "sys/systm.h"
+#include "sys/hwt_record.h"
 #include "sys/types.h"
+#include "libpmcstat_stubs.h"
+#include <libpmcstat.h>
+#include <libxo/xo.h>
 
 #define pt_strerror(errcode) pt_errstr(pt_errcode((errcode)))
 
@@ -62,19 +66,40 @@ static int pt_ctx_compare(const void *n1, const void *n2);
  */
 struct pt_dec_ctx {
 	size_t curoff;
-	size_t total;
+	uint64_t ts;
+	uint64_t curip;
 	void *tracebuf;
-	struct pt_packet_decoder *dec;
+	struct pt_block_decoder *dec;
 
 	int id;
 	RB_ENTRY(pt_dec_ctx) entry;
+
+	xo_handle_t *xop;
+	int dev_fd;
 };
+
+typedef void (
+    *pt_ctx_iter_cb)(struct trace_context *, struct pt_dec_ctx *, void *);
+
+static struct pt_image_section_cache *pt_iscache;
 
 static struct pt_dec_ctx *cpus;
 static RB_HEAD(threads, pt_dec_ctx) threads;
 RB_GENERATE_STATIC(threads, pt_dec_ctx, entry, pt_ctx_compare);
 
 static int kq_fd = -1;
+
+static void
+pt_ctx_sync_ts(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    uint64_t newts)
+{
+	size_t newoff;
+
+	newoff = (newts - dctx->ts) & (tc->bufsize - 1);
+
+	dctx->ts = newts;
+	dctx->curoff = newoff;
+}
 
 static int
 pt_ctx_compare(const void *n1, const void *n2)
@@ -85,11 +110,105 @@ pt_ctx_compare(const void *n1, const void *n2)
 	return (c1->id < c2->id ? -1 : c1->id > c2->id ? 1 : 0);
 }
 
+static void
+pt_foreach_ctx(struct trace_context *tc, pt_ctx_iter_cb callback, void *arg)
+{
+	int cpu_id;
+	struct pt_dec_ctx *dctx;
+
+	switch (tc->mode) {
+	case HWT_MODE_CPU:
+		CPU_FOREACH_ISSET(cpu_id, &tc->cpu_map) {
+			callback(tc, &cpus[cpu_id], arg);
+		}
+		break;
+	case HWT_MODE_THREAD:
+		RB_FOREACH(dctx, threads, &threads) {
+			callback(tc, dctx, arg);
+		}
+		break;
+	default:
+		errx(EXIT_FAILURE, "%s: unknown mode %d\n", __func__, tc->mode);
+		break;
+	}
+}
+
+static void
+pt_cpu_ctx_init_cb(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    void *arg __unused)
+{
+	int cpu_id, fd;
+	char filename[32];
+
+	cpu_id = dctx - cpus;
+	sprintf(filename, "/dev/hwt_%d_%d", tc->ident, cpu_id);
+	fd = open(filename, O_RDONLY);
+	if (fd < 0) {
+		errx(EXIT_FAILURE, "Can't open %s\n", filename);
+	}
+
+	/*
+	 * thr_fd is used to issue ioctls which control all
+	 * cores use fd to the first cpu for this (thread is
+	 * always 0).
+	 */
+	if (tc->thr_fd == 0) {
+		tc->thr_fd = fd;
+	}
+	dctx->tracebuf = mmap(NULL, tc->bufsize, PROT_READ, MAP_SHARED, fd, 0);
+	if (dctx->tracebuf == MAP_FAILED) {
+		errx(EXIT_FAILURE,
+		    "%s: failed to map tracing buffer for cpu %d: %s\n",
+		    __func__, cpu_id, strerror(errno));
+	}
+	dctx->id = cpu_id;
+}
+
+static void
+pt_update_image_cb(struct trace_context *tc __unused, struct pt_dec_ctx *dctx,
+    void *arg)
+{
+	int isid;
+	int error;
+	struct pt_image *image;
+
+	isid = *(int *)arg;
+	image = pt_blk_get_image(dctx->dec);
+	error = pt_image_add_cached(image, pt_iscache, isid, NULL);
+	if (error)
+		errx(EXIT_FAILURE,
+		    "%s: failed to add cached section to decoder image: %s",
+		    __func__, pt_strerror(error));
+}
+
+static int
+hwt_pt_image_load_cb(struct trace_context *tc, struct hwt_exec_img *img)
+{
+	int isid;
+
+	if (tc->raw)
+		return (0);
+	isid = pt_iscache_add_file(pt_iscache, img->path, img->offs, img->size,
+	    img->addr);
+	if (isid < 0) {
+		printf("%s: error adding file '%s' to the section cache: %s\n",
+		    __func__, img->path, pt_strerror(isid));
+		return (-1);
+	}
+
+	pt_foreach_ctx(tc, pt_update_image_cb, &isid);
+
+	return (0);
+}
+
 static int
 hwt_pt_init(struct trace_context *tc)
 {
 	struct kevent ev[2];
 	int error;
+
+	/* Buffer size must be power of two. */
+	assert((tc->bufsize & (tc->bufsize - 1)) == 0);
 
 	if (tc->raw) {
 		/* No decoder needed, just a file for raw data. */
@@ -106,7 +225,7 @@ hwt_pt_init(struct trace_context *tc)
 		cpus = calloc(hwt_ncpu(), sizeof(struct pt_dec_ctx));
 		if (!cpus) {
 			printf("%s: failed to allocate decoders\n", __func__);
-			return (-1);
+			return (ENOMEM);
 		}
 		break;
 	case HWT_MODE_THREAD:
@@ -119,7 +238,7 @@ hwt_pt_init(struct trace_context *tc)
 
 	tc->kqueue_fd = kqueue();
 	if (tc->kqueue_fd == -1)
-		err(EXIT_FAILURE, "kqueue() failed");
+		errx(EXIT_FAILURE, "kqueue() failed");
 	kq_fd = tc->kqueue_fd; /* sig handler needs access to kq via global */
 
 	/* Let hwt notify us when the buffer is ready. */
@@ -131,10 +250,15 @@ hwt_pt_init(struct trace_context *tc)
 
 	error = kevent(tc->kqueue_fd, ev, 2, NULL, 0, NULL);
 	if (error == -1)
-		err(EXIT_FAILURE, "kevent register");
+		errx(EXIT_FAILURE, "kevent register");
 	if ((ev[0].flags | ev[1].flags) & EV_ERROR)
 		// TODO: properly check per-event errors
 		errx(EXIT_FAILURE, "Event error: %s", strerror(ev[0].data));
+
+	pt_iscache = pt_iscache_alloc(tc->image_name);
+	if (pt_iscache == NULL)
+		errx(EXIT_FAILURE, "%s: failed to allocate section cache",
+		    __func__);
 
 	printf("%s kqueue_fd:%d\n", __func__, tc->kqueue_fd);
 
@@ -144,39 +268,15 @@ hwt_pt_init(struct trace_context *tc)
 static int
 hwt_pt_mmap(struct trace_context *tc, struct hwt_record_user_entry *rec)
 {
-	int cpu_id, tid, fd;
-	struct pt_dec_ctx *dctx;
-	struct pt_config config;
+	int tid, fd;
 	char filename[32];
+	struct pt_config config;
+	struct pt_image *srcimg, *dstimg;
+	struct pt_dec_ctx *dctx, *srcctx;
 
 	switch (tc->mode) {
 	case HWT_MODE_CPU:
-		CPU_FOREACH_ISSET (cpu_id, &tc->cpu_map) {
-			dctx = &cpus[cpu_id];
-
-			sprintf(filename, "/dev/hwt_%d_%d", tc->ident, cpu_id);
-			fd = open(filename, O_RDONLY);
-			if (fd < 0) {
-				printf("Can't open %s\n", filename);
-				return (-1);
-			}
-			/* thr_fd is used to issue ioctls which control all
-			 * cores use fd to the first cpu for this (thread is
-			 * always 0) */
-			if (tc->thr_fd == 0) {
-				tc->thr_fd = fd;
-			}
-			dctx->tracebuf = mmap(NULL, tc->bufsize, PROT_READ,
-			    MAP_SHARED, fd, 0);
-			if (dctx->tracebuf == MAP_FAILED) {
-				printf(
-				    "%s: failed to map tracing buffer for cpu %d: %s\n",
-				    __func__, cpu_id, strerror(errno));
-				free(dctx);
-				return (-1);
-			}
-			dctx->id = cpu_id;
-		}
+		pt_foreach_ctx(tc, pt_cpu_ctx_init_cb, NULL);
 		break;
 	case HWT_MODE_THREAD:
 		if (rec == NULL) {
@@ -190,7 +290,6 @@ hwt_pt_mmap(struct trace_context *tc, struct hwt_record_user_entry *rec)
 		dctx = calloc(1, sizeof(*dctx));
 		if (dctx == NULL)
 			return (ENOMEM);
-		// TODO: map thread trace buffer
 		sprintf(filename, "/dev/hwt_%d_%d", tc->ident, tid);
 		fd = open(filename, O_RDONLY);
 		if (fd < 0) {
@@ -201,6 +300,7 @@ hwt_pt_mmap(struct trace_context *tc, struct hwt_record_user_entry *rec)
 		if (tc->thr_fd == 0) {
 			tc->thr_fd = fd;
 		}
+		dctx->dev_fd = fd;
 		dctx->tracebuf = mmap(NULL, tc->bufsize, PROT_READ, MAP_SHARED,
 		    fd, 0);
 		if (dctx->tracebuf == MAP_FAILED) {
@@ -211,6 +311,13 @@ hwt_pt_mmap(struct trace_context *tc, struct hwt_record_user_entry *rec)
 			return (-1);
 		}
 		dctx->id = tid;
+		/* Grab another context, if any, and copy its decoder image. */
+		if (!RB_EMPTY(&threads)) {
+			srcctx = RB_ROOT(&threads);
+			srcimg = pt_blk_get_image(srcctx->dec);
+			dstimg = pt_blk_get_image(dctx->dec);
+			pt_image_copy(dstimg, srcimg);
+		}
 		RB_INSERT(threads, &threads, dctx);
 		break;
 	default:
@@ -223,7 +330,7 @@ hwt_pt_mmap(struct trace_context *tc, struct hwt_record_user_entry *rec)
 		config.begin = dctx->tracebuf;
 		config.end = (uint8_t *)dctx->tracebuf + tc->bufsize;
 
-		dctx->dec = pt_pkt_alloc_decoder(&config);
+		dctx->dec = pt_blk_alloc_decoder(&config);
 		if (dctx->dec == NULL) {
 			printf("%s: failed to allocate PT decoder for thread\n",
 			    __func__);
@@ -275,147 +382,101 @@ hwt_pt_set_config(struct trace_context *tc)
 }
 
 static void
-hwt_pt_print_tnt(const struct pt_packet_tnt *packet)
+hwt_pt_print(struct trace_context *tc, struct pt_dec_ctx *dctx, uint64_t ip)
 {
-	uint64_t tnt;
-	uint8_t bits;
+	uint64_t newpc;
+	unsigned long offset;
+	struct pmcstat_symbol *sym;
+	struct pmcstat_image *image;
+	const char *piname;
+	const char *psname;
 
-	bits = packet->bit_size;
-	tnt = packet->payload;
+	sym = hwt_sym_lookup(tc, ip, &image, &newpc);
+	if (sym || image) {
+		xo_emit_h(dctx->xop, "{:type/%s} {:id/%d}\t",
+		    tc->mode == HWT_MODE_CPU ? "CPU" : "thr", dctx->id);
+		xo_emit_h(dctx->xop, "{:pc/pc 0x%08lx/%x}", ip);
+		xo_emit_h(dctx->xop, " ");
+	}
 
-	while (--bits)
-		putc(tnt & (1ull << (bits - 1)) ? '!' : '.', stdout);
-}
-
-static void
-hwt_pt_print_mode(const struct pt_packet_mode *pkt)
-{
-	enum pt_exec_mode mode;
-
-	switch (pkt->leaf) {
-	case pt_mol_exec: {
-		printf(".exec: ");
-		mode = pt_get_exec_mode(&pkt->bits.exec);
-		switch (mode) {
-		case ptem_64bit:
-			printf("64-bit");
-			break;
-		case ptem_32bit:
-			printf("32-bit");
-			break;
-		case ptem_16bit:
-			printf("16-bit");
-			break;
-		default:
-			printf("unknown");
-			break;
+	if (image) {
+		if (tc->mode == HWT_MODE_THREAD) {
+			xo_emit_h(dctx->xop, "{:newpc/(%lx)/%x}", newpc);
+			xo_emit_h(dctx->xop, "\t");
 		}
-		break;
+
+		piname = pmcstat_string_unintern(image->pi_name);
+		xo_emit_h(dctx->xop, "{:piname/%12s/%s}", piname);
 	}
-	case pt_mol_tsx:
-		printf(".tsx");
-		break;
+
+	if (sym) {
+		psname = pmcstat_string_unintern(sym->ps_name);
+		offset = newpc - (sym->ps_start + image->pi_vaddr);
+		xo_emit_h(dctx->xop, "\t");
+		xo_emit_h(dctx->xop, "{:psname/%s/%s}", psname);
+		xo_emit_h(dctx->xop, "{:offset/+0x%lx/%ju}", offset);
+	}
+
+	if (sym || image) {
+		xo_emit_h(dctx->xop, "\n");
+		xo_close_instance("entry");
 	}
 }
 
 static int
-hwt_pt_print_packet(const struct pt_packet *pkt)
+hwt_pt_decode_chunk(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    uint64_t start, size_t len, uint64_t *processed)
 {
-
-	switch (pkt->type) {
-	case ppt_unknown:
-		printf("<unknown>");
-		break;
-	case ppt_invalid:
-		printf("<invalid>");
-		break;
-	case ppt_tnt_8:
-		printf("tnt.8\n");
-		hwt_pt_print_tnt(&pkt->payload.tnt);
-		break;
-	case ppt_tnt_64:
-		printf("tnt.64\n");
-		hwt_pt_print_tnt(&pkt->payload.tnt);
-		break;
-	case ppt_mode:
-		printf("mode");
-		hwt_pt_print_mode(&pkt->payload.mode);
-		break;
-	case ppt_pip:
-		printf("pip: cr3 %p", (void *)pkt->payload.pip.cr3);
-		break;
-	case ppt_vmcs:
-		printf("vmcs: %p", (void *)pkt->payload.vmcs.base);
-		break;
-	case ppt_cbr:
-		printf("cbr: ratio %u", pkt->payload.cbr.ratio);
-		break;
-	case ppt_tip_pge:
-		printf("pge: TRACE START @%p", (void *)pkt->payload.ip.ip);
-		break;
-	case ppt_tip_pgd:
-		printf("pgd: TRACE STOP @%p", (void *)pkt->payload.ip.ip);
-		break;
-	case ppt_fup:
-		printf("fup: @%p", (void *)pkt->payload.ip.ip);
-		break;
-	case ppt_pad:
-	case ppt_psb:
-	case ppt_psbend:
-		/* Ignore */
-		return (0);
-	default:
-		printf("%s: unknown packet type encountered: %d\n", __func__,
-		    pkt->type);
-		return (-1);
-	}
-	printf("\n");
-
-	return (0);
-}
-
-static int
-hwt_pt_decode_chunk(struct pt_packet_decoder *dec, uint64_t start, size_t len,
-    uint64_t *processed)
-{
-	int error = 0;
-	uint64_t prevoffs, offs;
 	int ret;
-	struct pt_packet packet;
+	int error = 0;
+	struct pt_block blk;
+	struct pt_event event;
+	uint64_t prevoffs, offs;
+	struct pt_block_decoder *dec;
+	uint64_t oldoffs;
 
-	printf("%s: start %zu, len %zu\n", __func__, start, len);
-
+	dec = dctx->dec;
 	offs = prevoffs = start;
 	/* Set decoder to current offset. */
-	pt_pkt_sync_set(dec, start);
-
+	ret = pt_blk_sync_set(dec, start);
+	blk.ip = 0;
 	do {
-		ret = pt_pkt_next(dec, &packet, sizeof(packet));
+		while (ret & pts_event_pending) {
+			ret = pt_blk_event(dec, &event, sizeof(event));
+			pt_blk_get_offset(dec, &offs);
+			if (offs >= (start + len))
+				break;
+		}
+		ret = pt_blk_next(dec, &blk, sizeof(blk));
 		if (ret < 0) {
 			if (ret == -pte_eos) {
-				/* Restore previous offset */
-				pt_pkt_sync_set(dec, prevoffs);
-				offs = prevoffs;
-			} else {
-				error = ret;
-				printf("%s: error decoding next packet: %s\n",
-				    __func__, pt_strerror(error));
+				/* Restore to last valid offset. */
+				pt_blk_sync_backward(dec);
+				ret = 0;
+				break;
 			}
-			break;
-		}
-		error = hwt_pt_print_packet(&packet);
-		if (error < 0) {
-			printf("%s: error while processing packet: %s\n",
-			    __func__, pt_strerror(error));
-			break;
-		}
 
-		prevoffs = offs;
-		offs += ret;
-
-		if (offs > (start + len))
-			break;
-	} while (1);
+			ret = pt_blk_sync_forward(dec);
+			oldoffs = offs;
+			pt_blk_get_offset(dec, &offs);
+			if (ret <= 0 || offs >= (start + len) ||
+			    offs <= oldoffs) {
+				if (ret != -pte_eos) {
+					error = ret;
+					printf("ip: %p\n", (void *)blk.ip);
+					printf(
+					    "%s: error decoding next instruction: %s\n",
+					    __func__, pt_strerror(error));
+				}
+				break;
+			}
+		}
+		pt_blk_get_offset(dec, &offs);
+		/* Print new symbol offset. */
+		hwt_pt_print(tc, dctx, blk.ip);
+	} while (offs < (start + len));
+	pt_blk_get_offset(dec, &offs);
+	printf("len %p, offs %p\n", (void *)len, (void *)offs);
 	*processed = offs - start;
 
 	return (error);
@@ -444,9 +505,9 @@ pt_process_chunk(struct trace_context *tc, struct pt_dec_ctx *dctx,
     uint64_t offs, size_t len, uint64_t *processed)
 {
 	if (tc->raw) {
-		return hwt_pt_dump_chunk(dctx, tc->raw_f, offs, len, processed);
+		return (hwt_pt_dump_chunk(dctx, tc->raw_f, offs, len, processed));
 	} else {
-		return hwt_pt_decode_chunk(dctx->dec, offs, len, processed);
+		return (hwt_pt_decode_chunk(tc, dctx, offs, len, processed));
 	}
 }
 
@@ -456,11 +517,11 @@ pt_get_decoder_ctx(struct trace_context *tc, int ctxid)
 	switch (tc->mode) {
 	case HWT_MODE_CPU:
 		assert(ctxid < hwt_ncpu());
-		return &cpus[ctxid];
+		return (&cpus[ctxid]);
 	case HWT_MODE_THREAD: {
 		struct pt_dec_ctx srch;
 		srch.id = ctxid;
-		return RB_FIND(threads, &threads, &srch);
+		return (RB_FIND(threads, &threads, &srch));
 	}
 	default:
 		break;
@@ -470,70 +531,107 @@ pt_get_decoder_ctx(struct trace_context *tc, int ctxid)
 }
 
 static int
-pt_process_data(struct trace_context *tc, struct kevent *tevent)
+pt_process_data(struct trace_context *tc, struct pt_dec_ctx *dctx, uint64_t ts)
 {
 	int error;
-	size_t newoff, curoff, len;
 	uint64_t processed;
-	int id;
-	struct pt_dec_ctx *dctx;
+	size_t newoff, curoff, len;
 
-	id = tevent->fflags & HWT_KQ_BUFRDY_ID_MASK;
-	newoff = tevent->data;
-	printf("%s: new offset %zu for ctx id %d\n", __func__, newoff, id);
-
-	dctx = pt_get_decoder_ctx(tc, id);
-	if (dctx == NULL) {
-		printf("%s: unable to find decorder context for ID %d\n",
-		    __func__, id);
-		err(EXIT_FAILURE, "pt_get_decoder_ctx");
+	/*
+	 * Check if the buffer overflowed since
+	 * the last time we processed it
+	 * and try to resync.
+	 */
+	if ((ts - dctx->ts) > tc->bufsize) {
+		printf(
+		    "%s: WARNING: buffer wrapped - re-syncing to last known offset\n",
+		    __func__);
+		pt_ctx_sync_ts(tc, dctx, ts);
+		return (0);
 	}
 
+	len = ts - dctx->ts;
 	curoff = dctx->curoff;
-	if (newoff == curoff) {
-		if (tc->terminate)
-			return (-1);
-	} else if (newoff > curoff) {
+	newoff = (curoff + len) % tc->bufsize;
+
+	if (newoff > curoff) {
 		/* New entries in the trace buffer. */
 		len = newoff - curoff;
 		error = pt_process_chunk(tc, dctx, curoff, len, &processed);
 		if (error != 0) {
-			return error;
+			return (error);
 		}
-		dctx->total += processed;
 		dctx->curoff += processed;
+		dctx->ts += processed;
 
 	} else if (newoff < curoff) {
 		/* New entries in the trace buffer. Buffer wrapped. */
 		len = tc->bufsize - curoff;
 		error = pt_process_chunk(tc, dctx, curoff, len, &processed);
 		if (error != 0) {
-			return error;
+			return (error);
 		}
 
 		dctx->curoff += processed;
-		dctx->total += processed;
+		dctx->ts += processed;
 
 		curoff = 0;
 		len = newoff;
 		error = pt_process_chunk(tc, dctx, curoff, len, &processed);
 		if (error != 0) {
-			return error;
+			return (error);
 		}
 
-		dctx->curoff += processed;
-		dctx->total += processed;
+		dctx->curoff = processed;
+		dctx->ts += processed;
 	}
 
 	return (0);
 }
 
 static int
+pt_get_offs(int dev_fd, uint64_t *offs)
+{
+	struct hwt_bufptr_get bget;
+	vm_offset_t curpage_offset;
+	int curpage;
+	int error;
+
+	bget.curpage = &curpage;
+	bget.curpage_offset = &curpage_offset;
+
+	error = ioctl(dev_fd, HWT_IOC_BUFPTR_GET, &bget);
+	if (error)
+		return (error);
+
+	*offs = curpage * PAGE_SIZE + curpage_offset;
+
+	return (0);
+}
+
+static void
+pt_ctx_process_cb(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    void *arg __unused)
+{
+	int error;
+	uint64_t ts;
+
+	error = pt_get_offs(dctx->dev_fd, &ts);
+	if (error)
+		errx(EXIT_FAILURE, "pt_get_offs");
+	error = pt_process_data(tc, dctx, ts);
+	if (error)
+		errx(EXIT_FAILURE, "pt_process_data");
+}
+
+static int
 hwt_pt_process(struct trace_context *tc)
 {
-	int error, nrec, ret;
+	int status;
+	int ret, id;
+	int nrec, error;
 	struct kevent tevent;
-	struct timespec null_timeout = { 0, 5 };
+	struct pt_dec_ctx *dctx;
 
 	xo_open_container("trace");
 	xo_open_list("entries");
@@ -541,51 +639,60 @@ hwt_pt_process(struct trace_context *tc)
 	printf("Decoder started. Press ctrl+c to stop.\n");
 
 	while (1) {
-		printf("%s: waiting for new offset\n", __func__);
-		ret = kevent(tc->kqueue_fd, NULL, 0, &tevent, 1, NULL);
-		if (ret == -1 && errno != EINTR) {
-			err(EXIT_FAILURE, "kevent wait");
+		waitpid(tc->pid, &status, WNOHANG);
+		if (WIFEXITED(status)) {
+			tc->terminate = 1;
 		}
-		// TODO: iterate over all active CTXs and fetch any remaining
-		// data
-		if (tc->terminate != 0) {
+		if (!tc->terminate) {
+			printf("%s: waiting for new offset\n", __func__);
+			ret = kevent(tc->kqueue_fd, NULL, 0, &tevent, 1, NULL);
+			if (ret == -1) {
+				errx(EXIT_FAILURE, "kevent wait");
+			}
+		}
+		if (errno == EINTR || tc->terminate) {
 			printf(
 			    "%s: tracing terminated - fetching remaining data\n",
 			    __func__);
-			/* Check if we have any events left over. */
-			if (ret > 0) {
-				pt_process_data(tc, &tevent);
-			}
-			while (1) {
-				ret = kevent(tc->kqueue_fd, NULL, 0, &tevent, 1,
-				    &null_timeout);
-				if (ret <= 0) {
+			/* Fetch any remaining records. */
+			do {
+				error = hwt_record_fetch(tc, &nrec);
+				if (error != 0 || nrec == 0)
 					break;
-				}
-				/* Ignore non-buffer events. */
-				if (tevent.ident != HWT_KQ_BUFRDY_EV)
-					continue;
-				pt_process_data(tc, &tevent);
-			}
+			} while (1);
 
+			/*
+			 * Iterate over all records and process remaining data.
+			 */
+			pt_foreach_ctx(tc, pt_ctx_process_cb, NULL);
 			return (0);
 		}
 
 		printf("EVENT ID: %lu\n", tevent.ident);
 		if (tevent.ident == HWT_KQ_BUFRDY_EV) {
-			pt_process_data(tc, &tevent);
+			id = tevent.fflags & HWT_KQ_BUFRDY_ID_MASK;
+			dctx = pt_get_decoder_ctx(tc, id);
+			if (dctx == NULL) {
+				printf(
+				    "%s: unable to find decorder context for ID %d\n",
+				    __func__, id);
+			}
+			errx(EXIT_FAILURE, "pt_get_decoder_ctx");
+
+			error = pt_process_data(tc, dctx, tevent.data);
+			if (error)
+				errx(EXIT_FAILURE, "pt_process_data");
 		} else if (tevent.ident == HWT_KQ_NEW_RECORD_EV) {
 			printf("%s: fetching new records\n", __func__);
-			error = hwt_record_fetch(tc, &nrec);
-			if (error != 0) {
-				printf("%s: hwt_get_records error %d\n",
-				    __func__, error);
-				err(EXIT_FAILURE, "hwt_get_records");
-			}
+			do {
+				error = hwt_record_fetch(tc, &nrec);
+				if (error != 0 || nrec == 0)
+					break;
+			} while (1);
 		} else {
 			printf("%s: unknown event identifier %lu\n", __func__,
 			    tevent.ident);
-			err(EXIT_FAILURE, "kevent ident");
+			errx(EXIT_FAILURE, "kevent ident");
 		}
 	}
 
@@ -597,9 +704,9 @@ hwt_pt_process(struct trace_context *tc)
 	return (0);
 }
 
-struct trace_dev_methods pt_methods = {
-	.init = hwt_pt_init,
+struct trace_dev_methods pt_methods = { .init = hwt_pt_init,
 	.mmap = hwt_pt_mmap,
 	.process = hwt_pt_process,
 	.set_config = hwt_pt_set_config,
+	.image_load_cb = hwt_pt_image_load_cb
 };

--- a/usr.sbin/hwt/hwt_record.c
+++ b/usr.sbin/hwt/hwt_record.c
@@ -48,6 +48,7 @@
 #include <string.h>
 
 #include "hwt.h"
+#include "hwt_elf.h"
 
 #include "libpmcstat_stubs.h"
 #include <libpmcstat.h>
@@ -61,27 +62,69 @@
 #define	dprintf(fmt, ...)
 #endif
 
-int
-hwt_record_fetch(struct trace_context *tc, int *nrecords)
+static int
+hwt_record_to_elf_img(struct trace_context *tc,
+    struct hwt_record_user_entry *entry, struct hwt_exec_img *img)
 {
-	struct hwt_record_user_entry *entry;
 	pmcstat_interned_string path;
 	struct pmcstat_image *image;
 	struct pmc_plugins plugins;
 	struct pmcstat_args args;
 	unsigned long addr;
-	struct hwt_record_get record_get;
 	char imagepath[PATH_MAX];
-	struct stat st;
-	int nentries;
-	int error;
-	int j;
+
+	dprintf("  path %s addr %lx\n", entry->fullpath,
+	    (unsigned long)entry->addr);
 
 	memset(&plugins, 0, sizeof(struct pmc_plugins));
 	memset(&args, 0, sizeof(struct pmcstat_args));
 	args.pa_fsroot = "/";
-	nentries = 256;
+	path = pmcstat_string_intern(entry->fullpath);
+	image = pmcstat_image_from_path(path, 0, &args, &plugins);
+	if (image == NULL)
+		return (-1);
 
+	if (image->pi_type == PMCSTAT_IMAGE_UNKNOWN)
+		pmcstat_image_determine_type(image, &args);
+
+	if (image->pi_end == 0) {
+		printf("  image '%s' has no executable sections, skipping\n",
+		    imagepath);
+		free(image);
+		image = NULL;
+		img->size = 0;
+		return (0);
+	}
+	addr = (unsigned long)entry->addr & ~1;
+	if (entry->record_type != HWT_RECORD_KERNEL)
+		addr -= (image->pi_start - image->pi_vaddr);
+
+	pmcstat_image_link(tc->pp, image, addr);
+	dprintf("image pi_vaddr %lx pi_start %lx"
+		" pi_end %lx pi_entry %lx\n",
+	    (unsigned long)image->pi_vaddr, (unsigned long)image->pi_start,
+	    (unsigned long)image->pi_end, (unsigned long)image->pi_entry);
+
+	if (hwt_elf_get_text_offs(entry->fullpath, &img->offs))
+		return (-1);
+	img->size = image->pi_end - image->pi_start;
+	img->addr = addr;
+	img->path = entry->fullpath;
+
+	return (0);
+}
+
+int
+hwt_record_fetch(struct trace_context *tc, int *nrecords)
+{
+	struct hwt_record_user_entry *entry;
+	struct hwt_record_get record_get;
+	struct hwt_exec_img img;
+	int nentries;
+	int error;
+	int j;
+
+	nentries = 256;
 	tc->records = malloc(sizeof(struct hwt_record_user_entry) * nentries);
 
 	record_get.records = tc->records;
@@ -104,58 +147,15 @@ hwt_record_fetch(struct trace_context *tc, int *nrecords)
 		case HWT_RECORD_MUNMAP:
 		case HWT_RECORD_EXECUTABLE:
 		case HWT_RECORD_INTERP:
-			printf("  lib #%d: path %s addr %lx\n", j,
-			    entry->fullpath,
-			    (unsigned long)entry->addr);
-
-			path = pmcstat_string_intern(entry->fullpath);
-			image = pmcstat_image_from_path(path, 0, &args,
-			    &plugins);
-			if (image == NULL)
-				return (-1);
-
-			if (image->pi_type == PMCSTAT_IMAGE_UNKNOWN)
-				pmcstat_image_determine_type(image, &args);
-
-			addr = (unsigned long)entry->addr & ~1;
-			addr -= (image->pi_start - image->pi_vaddr);
-			pmcstat_image_link(tc->pp, image, addr);
-			dprintf("image pi_vaddr %lx pi_start %lx"
-			    " pi_entry %lx\n",
-			    (unsigned long)image->pi_vaddr,
-			    (unsigned long)image->pi_start,
-			    (unsigned long)image->pi_entry);
-			hwt_mmap_received(tc, entry);
-			break;
 		case HWT_RECORD_KERNEL:
-			snprintf(imagepath, sizeof(imagepath), "%s/%s",
-			    tc->fs_root, entry->fullpath);
-			error = stat(imagepath, &st);
-			if (error)
-				errx(EX_OSERR, "Image \"%s\" not found\n",
-				    imagepath);
-			printf("  image #%d: path %s addr %lx\n", j,
-			    imagepath, (unsigned long)entry->addr);
-			path = pmcstat_string_intern(imagepath);
-			image = pmcstat_image_from_path(path, 1, &args,
-			    &plugins);
-			if (image == NULL)
-				return (-1);
-			if (image->pi_type == PMCSTAT_IMAGE_UNKNOWN)
-				pmcstat_image_determine_type(image, &args);
-			/*
-			 * Some images have no executable sections - skip them.
-			 */
-			if (image->pi_end == 0) {
-				printf(
-				    "  image '%s' has no executable sections, skipping\n",
-				    imagepath);
-				free(image);
-				image = NULL;
-				break;
-			}
-			addr = (unsigned long)entry->addr & ~1;
-			pmcstat_image_link(tc->pp, image, addr);
+			hwt_record_to_elf_img(tc, entry, &img);
+			/* Invoke backend callback, if any. */
+			if (tc->trace_dev->methods->image_load_cb != NULL &&
+			    (error = tc->trace_dev->methods->image_load_cb(tc,
+					 &img) != 0))
+				return (error);
+			if (entry->record_type != HWT_RECORD_KERNEL)
+				hwt_mmap_received(tc, entry);
 			break;
 		case HWT_RECORD_THREAD_CREATE:
 			/* Let the backend register the newly created thread. */
@@ -169,6 +169,8 @@ hwt_record_fetch(struct trace_context *tc, int *nrecords)
 			break;
 		}
 	}
+	free(tc->records);
+	tc->records = NULL;
 
 	*nrecords = nentries;
 

--- a/usr.sbin/hwt/hwt_record.c
+++ b/usr.sbin/hwt/hwt_record.c
@@ -161,7 +161,7 @@ hwt_record_fetch(struct trace_context *tc, int *nrecords)
 			/* Let the backend register the newly created thread. */
 			if ((error = tc->trace_dev->methods->mmap(tc, entry)) !=
 			    0)
-				return error;
+				return (error);
 			break;
 		case HWT_RECORD_THREAD_SET_NAME:
 			break;


### PR DESCRIPTION
This PR adds a few fixes, QoL changes, and most importantly a working PT decoder.

The decoder uses `libipt` (`contrib/processor-trace/libipt`) to decode the traces generated by the PT hardware.
The library also needs access to the underlying machine code to fully decode the trace, which is why the PT decoder will effectively load .text sections for each image loaded by the traced process. This is done when receiving MMAP or EXEC records.