### PR TITLE
Introduce the `-o` flag and refactor the userspace PT backend.

### DIFF
--- a/usr.sbin/hwt/Makefile
+++ b/usr.sbin/hwt/Makefile
@@ -16,7 +16,10 @@ SRCS=	hwt.c			\
 SRCS+=	hwt_coresight.c hwt_spe.c
 LIBADD+= opencsd
 .elif ${MACHINE_CPUARCH} == "amd64"
-SRCS+=  hwt_pt.c
+SRCS+=  hwt_pt.c	 \
+	 pt/pt_decode.c  \
+	 pt/pt_dump.c 	 \
+	 pt/pt_fmt.c
 LIBADD+= ipt
 .endif
 

--- a/usr.sbin/hwt/Makefile
+++ b/usr.sbin/hwt/Makefile
@@ -6,6 +6,7 @@ CFLAGS+= -I${SRCTOP}/lib/libpmcstat -I${SRCTOP}/sys
 LIBADD= elf pmcstat xo util
 
 SRCS=	hwt.c			\
+	hwt_fmt.c		\
 	hwt_elf.c		\
 	hwt_process.c		\
 	hwt_record.c		\

--- a/usr.sbin/hwt/hwt.8
+++ b/usr.sbin/hwt/hwt.8
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd April 06, 2025
+.Dd May 05, 2025
 .Dt hwt 8
 .Os
 .Sh NAME
@@ -34,10 +34,11 @@
 .Op Fl c Ar devname
 .Op Fl f Ar name
 .Op Fl i Ar name
+.Op Fl o Ar format
 .Op Fl P Ar pid
 .Op Fl R Ar fsroot
-.Op Fl t Ar tid
 .Op Fl s Ar cpuid
+.Op Fl t Ar tid
 .Op Fl w Ar path
 .Op Ar path
 .Sh DESCRIPTION
@@ -71,6 +72,9 @@ will select the first available backend if this flag is not passed.
 Filter trace by function name.
 .It Fl i Ar obj
 Filter trace by dynamic library, executable, kernel module, or 'kernel'.
+.It Fl o Ar format
+Print information specified by a list of comma separated keywords when decoding
+an execution trace.
 .It Fl P Ar pid
 Attach to process specified by
 .Ar pid .
@@ -86,6 +90,24 @@ when tracing in thread mode.
 Store decoded trace to file specified by
 .Ar path.
 .El
+.Pp
+.Nm
+currently supports the following format keywords:
+.Bl -tag -width lockname
+.It Cm offset
+The trace file offset.
+.It Cm id
+CPU core or thread ID.
+.It Cm image
+Executable program associated with the decoded program counter.
+.It Cm symbol
+Function symbol associated with the decoded program counter.
+.It Cm pc
+Program counter value.
+.It Cm event_type
+Tracing event type.
+.It Cm event_payload
+Payload associated with a generated tracing event.
 .Sh EXIT STATUS
 .Ex -std
 .Sh EXAMPLES

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -65,6 +65,8 @@
 #endif
 
 #if defined(__amd64__)
+#include <sys/tree.h>
+
 #include "hwt_pt.h"
 #endif
 
@@ -90,7 +92,7 @@ static struct trace_dev trace_devs[] = {
 	{ "spe",	"ARM Statistical Profiling Extension", &spe_methods },
 #endif
 #if defined(__amd64__)
-	{ "pt", "Intel PT", &pt_methods},
+	{ "pt",		"Intel Processor Trace", &pt_methods},
 #endif
 	{ NULL, NULL, NULL }
 };

--- a/usr.sbin/hwt/hwt.c
+++ b/usr.sbin/hwt/hwt.c
@@ -309,6 +309,7 @@ usage(void)
 		"\t -b\tbufsize\t\tSize of trace buffer (per each thread/cpu)\n"
 		"\t\t\t\tin bytes. Must be a multiple of page size\n"
 		"\t\t\t\te.g. 4096.\n"
+		"\t -o\tkeywords\t\tList of decoder output keywords.\n"
 		"\t -t\tid\t\tThread index of application passed to decoder.\n"
 		"\t -r\t\t\tRaw flag. Do not decode results.\n"
 		"\t -w\tfilename\tStore results into file.\n"
@@ -675,13 +676,14 @@ main(int argc, char **argv, char **env)
 	tc->fs_root = "/";
 	tc->thread_id = 0;
 	tc->attach = 0;
+	tc->fmt = HWT_FMT_DEFAULT_COLS;
 	thread_id_specified = 0;
 
 	argc = xo_parse_args(argc, argv);
 	if (argc < 0)
 		exit(EXIT_FAILURE);
 
-	while ((option = getopt(argc, argv, "P:R:gs:hc:b:rw:t:i:f:")) != -1)
+	while ((option = getopt(argc, argv, "P:R:gs:hc:b:rw:t:i:f:o:")) != -1)
 		switch (option) {
 		case 'P':
 			tc->attach = 1;
@@ -713,6 +715,9 @@ main(int argc, char **argv, char **env)
 			break;
 		case 'b':
 			tc->bufsize = atol(optarg);
+			break;
+		case 'o':
+			tc->fmt = hwt_fmt_parse_cols(optarg);
 			break;
 		case 'r':
 			/* Do not decode trace. */

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -30,6 +30,7 @@
 #ifndef	_HWTVAR_H_
 #define	_HWTVAR_H_
 
+#include "hwt_fmt.h"
 #define	TC_MAX_ADDR_RANGES	16
 
 struct trace_context;
@@ -120,6 +121,7 @@ struct trace_context {
 
 	int mode;
 	const char *fs_root;
+	enum hwt_fmt_column fmt;
 };
 
 struct pmcstat_process *hwt_process_alloc(void);

--- a/usr.sbin/hwt/hwt.h
+++ b/usr.sbin/hwt/hwt.h
@@ -42,7 +42,7 @@ struct trace_dev_methods {
 	void (*shutdown)(struct trace_context *tc);
 
 	/*
-	 * Called whenever a tracing buffer needs to mapped into hwt.
+	 * Called whenever a tracing buffer is mapped into hwt.
 	 */
 	int (*mmap)(struct trace_context *tc,
 	    struct hwt_record_user_entry *entry);

--- a/usr.sbin/hwt/hwt_fmt.c
+++ b/usr.sbin/hwt/hwt_fmt.c
@@ -1,0 +1,133 @@
+/*-
+ * Copyright (c) 2025 Bojan Novković  <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/hwt.h>
+#include <sys/hwt_record.h>
+#include <sys/param.h>
+
+#include <assert.h>
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <libxo/xo.h>
+
+#include "libpmcstat_stubs.h"
+#include <libpmcstat.h>
+
+#include "hwt.h"
+#include "hwt_fmt.h"
+
+static struct column {
+	const char *name;
+	enum hwt_fmt_column val;
+} columns[] = {
+	{ "offset", HWT_FMT_OFFSET },
+	{ "id", HWT_FMT_ID },
+	{ "image", HWT_FMT_IMAGE_NAME },
+	{ "symbol", HWT_FMT_SYM_NAME },
+	{ "pc", HWT_FMT_PC },
+	{ "event_type", HWT_FMT_EV_TYPE },
+	{ "event_payload", HWT_FMT_EV_PAYLOAD },
+	{ "disas", HWT_FMT_DISAS },
+};
+
+void
+hwt_fmt_print_generic(struct trace_context *tc, xo_handle_t *xop, int id,
+    uint64_t pc, uint64_t offs)
+{
+	uint64_t newpc;
+	unsigned long offset;
+	struct pmcstat_symbol *sym;
+	struct pmcstat_image *image;
+	const char *piname;
+	const char *psname;
+
+	if (HWT_FMT_SHOULD_PRINT(tc->fmt, OFFSET))
+		xo_emit_h(xop, "{:trace_offset/%#lx}\t", offs);
+
+	if (HWT_FMT_SHOULD_PRINT(tc->fmt, ID))
+		xo_emit_h(xop, "{:type/%s} {:id/%d}\t",
+		    tc->mode == HWT_MODE_CPU ? "CPU" : "thr", id);
+
+	if (HWT_FMT_SHOULD_PRINT_COLS(tc->fmt,
+	    (HWT_FMT_SYM_NAME | HWT_FMT_IMAGE_NAME))){
+		sym = hwt_sym_lookup(tc, pc, &image, &newpc);
+		if (HWT_FMT_SHOULD_PRINT(tc->fmt, IMAGE_NAME)) {
+			if (!image)
+				piname = "?";
+			else
+				piname = pmcstat_string_unintern(image->pi_name);
+			xo_emit_h(xop, "{:image_name/%s}\t", piname);
+		}
+
+		if (HWT_FMT_SHOULD_PRINT(tc->fmt, SYM_NAME))  {
+			if (!sym) {
+				psname = "?";
+				offset = 0;
+			} else {
+				psname = pmcstat_string_unintern(sym->ps_name);
+				offset = newpc -
+				    (sym->ps_start + (image != NULL ? image->pi_vaddr : 0));
+			}
+			xo_emit_h(xop, "{:sym_name/%s}{:sym_offset/+%#lx}\t", psname, offset);
+		}
+	}
+
+	if (HWT_FMT_SHOULD_PRINT(tc->fmt, PC))
+		xo_emit_h(xop, "{:PC/%#lx}\t", pc);
+}
+
+enum hwt_fmt_column
+hwt_fmt_parse_cols(const char* args)
+{
+	size_t i;
+	char *orig, *tok;
+	enum hwt_fmt_column ret;
+
+	ret = 0;
+	orig = strdup(args);
+	if (orig == NULL)
+		err(1, "strdup");
+	while ((tok = strsep(&orig, ",")) != NULL) {
+		for (i = 0; i < nitems(columns); i++) {
+			if (strcmp(columns[i].name, tok) == 0) {
+				ret |= columns[i].val;
+				break;
+			}
+		}
+		if (i == nitems(columns)) {
+			fprintf(stderr, "Unknown output column name '%s'", tok);
+			exit(1);
+		}
+	}
+
+	free(orig);
+	return (ret);
+}

--- a/usr.sbin/hwt/hwt_fmt.h
+++ b/usr.sbin/hwt/hwt_fmt.h
@@ -1,0 +1,52 @@
+/*-
+ * Copyright (c) 2025 Bojan Novković  <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#ifndef _HWT_FMT_H_
+#define _HWT_FMT_H_
+
+#include <libxo/xo.h>
+enum hwt_fmt_column {
+	HWT_FMT_OFFSET = 0x1,
+	HWT_FMT_ID = 0x2,
+	HWT_FMT_IMAGE_NAME = 0x4,
+	HWT_FMT_SYM_NAME = 0x8,
+	HWT_FMT_PC = 0x10,
+	HWT_FMT_EV_TYPE = 0x20,
+	HWT_FMT_EV_PAYLOAD = 0x40,
+	HWT_FMT_DISAS = 0x80,
+};
+
+#define HWT_FMT_SHOULD_PRINT_COLS(flags, cols) ((flags & (cols)) != 0)
+#define HWT_FMT_SHOULD_PRINT(flags, col) ((flags & HWT_FMT_##col) != 0)
+#define HWT_FMT_DEFAULT_COLS (HWT_FMT_OFFSET | HWT_FMT_ID | HWT_FMT_SYM_NAME | \
+	    HWT_FMT_PC)
+
+struct trace_context;
+void hwt_fmt_print_generic(struct trace_context *tc, xo_handle_t *xop, int id,
+    uint64_t pc, uint64_t offs);
+
+enum hwt_fmt_column hwt_fmt_parse_cols(const char *args);
+#endif /* _HWT_FMT_H_ */

--- a/usr.sbin/hwt/pt/pt_decode.c
+++ b/usr.sbin/hwt/pt/pt_decode.c
@@ -1,0 +1,129 @@
+/*-
+ * Copyright (c) 2025 Bojan Novković  <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <sys/errno.h>
+#include <sys/hwt.h>
+#include <sys/hwt_record.h>
+#include <sys/param.h>
+#include <sys/tree.h>
+
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <libxo/xo.h>
+#include <amd64/pt/pt.h>
+#include <libipt/intel-pt.h>
+
+#include "../hwt.h"
+#include "../hwt_pt.h"
+#include "../hwt_fmt.h"
+
+#include "pt_fmt.h"
+
+static int
+pt_decode_chunk_insn(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    uint64_t start, size_t len, uint64_t *processed)
+{
+	int ret;
+	int error;
+	uint64_t offs;
+	struct pt_insn insn;
+	struct pt_event event;
+	struct pt_config *cfg;
+	struct pt_insn_decoder *dec;
+
+	error = 0;
+	offs = start;
+	dec = dctx->dec;
+	/* Set decoder to current offset. */
+	cfg = __DECONST(struct pt_config *, pt_insn_get_config(dec));
+	cfg->end = (uint8_t *)dctx->tracebuf + (start + len);
+	ret = pt_insn_sync_set(dec, start);
+	do {
+		/* Process any pending events. */
+		while (ret & pts_event_pending) {
+			ret = pt_insn_event(dec, &event, sizeof(event));
+			pt_insn_get_offset(dec, &offs);
+			pt_print_event(tc, dctx, &event, start + offs);
+		}
+		ret = pt_insn_next(dec, &insn, sizeof(insn));
+		if (ret >= 0) {
+			pt_insn_get_offset(dec, &offs);
+			pt_print_insn(tc, dctx, &insn, start + offs);
+			continue;
+		}
+		if (ret == -pte_eos)
+			break;
+		/* A decoding error occured - try to resync.  */
+		ret = pt_insn_sync_forward(dec);
+		if (ret < 0) {
+			if (ret != -pte_eos) {
+				printf(
+				    "%s: error decoding next instruction: %s\n",
+				    __func__, pt_strerror(ret));
+				error = ret;
+			}
+			pt_insn_get_offset(dec, &offs);
+			break;
+		}
+		pt_insn_get_offset(dec, &offs);
+	} while (offs < (start + len));
+	pt_insn_get_offset(dec, &offs);
+	*processed = offs - start;
+
+	return (error);
+}
+
+static int
+pt_decode_generic_init(struct trace_context *tc, struct pt_dec_ctx *dctx)
+{
+	char filename[MAXPATHLEN];
+
+	if (tc->filename) {
+		snprintf(filename, MAXPATHLEN, "%s%d", tc->filename,
+		    dctx->id);
+		dctx->out = fopen(filename, "w");
+		if (dctx->out == NULL) {
+			printf("Could not open %s\n", filename);
+			return (ENXIO);
+		}
+		dctx->xop = xo_create_to_file(dctx->out, XO_STYLE_TEXT,
+		    XOF_WARN);
+	} else {
+		dctx->out = stdout;
+		dctx->xop = NULL;
+	}
+
+	return (0);
+}
+
+struct pt_decode_ops pt_decode_generic_ops = {
+	.init = pt_decode_generic_init,
+	.decode_chunk = pt_decode_chunk_insn
+};

--- a/usr.sbin/hwt/pt/pt_fmt.c
+++ b/usr.sbin/hwt/pt/pt_fmt.c
@@ -1,0 +1,96 @@
+/*-
+ * Copyright (c) 2025 Bojan Novković  <bnovkov@freebsd.org>
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+ * OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+
+#include <amd64/pt/pt.h>
+#include <sys/hwt.h>
+#include <sys/hwt_record.h>
+#include <sys/tree.h>
+
+#include <assert.h>
+#include <err.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <string.h>
+#include <signal.h>
+#include <unistd.h>
+
+#include <libipt/intel-pt.h>
+#include <libxo/xo.h>
+
+#include "../hwt.h"
+#include "../hwt_fmt.h"
+#include "../hwt_pt.h"
+
+#include "pt_fmt.h"
+
+void
+pt_print_insn(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    struct pt_insn *insn, uint64_t offs)
+{
+	xo_open_instance("entry");
+	hwt_fmt_print_generic(tc, dctx->xop, dctx->id, insn->ip, offs);
+
+	xo_emit_h(dctx->xop, "\n");
+	xo_close_instance("entry");
+}
+
+void
+pt_print_event(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    struct pt_event *ev, uint64_t offs)
+{
+	uint64_t ip;
+	const char* evname;
+
+	if (!HWT_FMT_SHOULD_PRINT_COLS(tc->fmt,
+	    HWT_FMT_EV_TYPE | HWT_FMT_EV_PAYLOAD))
+		return;
+
+	switch (ev->type) {
+	case ptev_enabled:
+		evname = "trace_start";
+		ip = ev->variant.enabled.ip;
+		break;
+	case ptev_disabled:
+		evname = "trace_stop";
+		ip = ev->variant.disabled.ip;
+		break;
+	default:
+		evname = "?";
+		ip = 0;
+		break;
+	}
+
+	xo_open_instance("entry");
+	hwt_fmt_print_generic(tc, dctx->xop, dctx->id, ip, offs);
+
+	if (HWT_FMT_SHOULD_PRINT(tc->fmt, EV_TYPE))
+		xo_emit_h(dctx->xop, "{:event_type}", evname);
+	if (HWT_FMT_SHOULD_PRINT(tc->fmt, EV_PAYLOAD))
+		xo_emit_h(dctx->xop, "{:event_payload/+0x%lx/%ju}", ip);
+
+	xo_emit_h(dctx->xop, "\n");
+	xo_close_instance("entry");
+}

--- a/usr.sbin/hwt/pt/pt_fmt.h
+++ b/usr.sbin/hwt/pt/pt_fmt.h
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2023 Bojan Novković <bnovkov@freebsd.org>
+ * Copyright (c) 2025 Bojan Novković  <bnovkov@freebsd.org>
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -24,38 +24,12 @@
  * SUCH DAMAGE.
  */
 
-#ifndef _HWT_PT_H_
-#define _HWT_PT_H_
+#ifndef _PT_FMT_H_
+#define _PT_FMT_H_
 
-#include <amd64/pt/pt.h>
+void pt_print_insn(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    struct pt_insn *insn, uint64_t offs);
+void pt_print_event(struct trace_context *tc, struct pt_dec_ctx *dctx,
+    struct pt_event *ev, uint64_t offs);
 
-#define pt_strerror(errcode) pt_errstr(pt_errcode((errcode)))
-
-/*
- * Trace decoder state.
- */
-struct pt_dec_ctx {
-	size_t curoff;
-	uint64_t ts;
-	uint64_t curip;
-	void *tracebuf;
-	struct pt_insn_decoder *dec;
-
-	int id;
-	RB_ENTRY(pt_dec_ctx) entry;
-
-	/* Variables for various decode ops. */
-	xo_handle_t *xop;
-	FILE *out;
-};
-
-struct pt_decode_ops {
-	int (*decode_chunk)(struct trace_context *, struct pt_dec_ctx *,
-	    uint64_t, size_t, uint64_t *);
-	int (*init)(struct trace_context *, struct pt_dec_ctx *);
-};
-extern struct pt_decode_ops pt_decode_generic_ops;
-extern struct pt_decode_ops pt_dump_ops;
-
-extern struct trace_dev_methods pt_methods;
-#endif /* !_HWT_PT_H_ */
+#endif /* _PT_FMT_H_ */


### PR DESCRIPTION
This PR fixes a couple of minor issues, introduces the ability to specify the decoder's output (`-o` flag), and converts the PT backend to use the printing facilities added by the `-o` option.

This should change aims to deduplicate printing code for each backend and make it easier to add backend-specific decoder output, such as the upcoming disassembly option for Intel PT.